### PR TITLE
Fixed typo in PageRank summary

### DIFF
--- a/asciidoc/courses/graph-data-science-fundamentals/modules/1-graph-algorithms/lessons/2-centrality-and-importance/lesson.adoc
+++ b/asciidoc/courses/graph-data-science-fundamentals/modules/1-graph-algorithms/lessons/2-centrality-and-importance/lesson.adoc
@@ -42,7 +42,7 @@ Another common centrality algorithm is PageRank. PageRank is a good algorithm fo
 
 PageRank was originally developed by Google co-founders Larry Page and Sergey Brin at Stanford University in 1996 as part of a research project about a new kind of search engine. It has since been used by Google Search to rank web pages in their search engine results.
 
-In summary, PageRank estimates the importance of a node by counting the number of incoming relationships from neighboring nodes weighted by the importance and out-degree centrality of those neighbors. The underlying assumption is that more important nodes are likely to have proportionately more incoming relationships from other import nodes. https://neo4j.com/docs/graph-data-science/current/algorithms/page-rank/[Our PageRank documentation^] offers a thorough technical explanation of PageRank if you are interested in digging in deeper.
+In summary, PageRank estimates the importance of a node by counting the number of incoming relationships from neighboring nodes weighted by the importance and out-degree centrality of those neighbors. The underlying assumption is that more important nodes are likely to have proportionately more incoming relationships from other important nodes. https://neo4j.com/docs/graph-data-science/current/algorithms/page-rank/[Our PageRank documentation^] offers a thorough technical explanation of PageRank if you are interested in digging in deeper.
 
 Below is an example of applying PageRank to find the most influential persons in the Director -> Actor network from movies released on or after 1990 with a revenue of at least 10 Million dollars.
 


### PR DESCRIPTION
In the summary for PageRank, there was a typo where the sentence said "The underlying assumption is that more important nodes are likely to have proportionately more incoming relationships from other import nodes" where the second to last word should have been 'important' not 'import'