### PR TITLE
Updates in 2 lessons of graph-data-science-fundamentals

### DIFF
--- a/asciidoc/courses/graph-data-science-fundamentals/modules/2-machine-learning-procedures/lessons/3-node-classification/lesson.adoc
+++ b/asciidoc/courses/graph-data-science-fundamentals/modules/2-machine-learning-procedures/lessons/3-node-classification/lesson.adoc
@@ -64,9 +64,9 @@ CALL gds.graph.project('proj',
     }
 );
 
-CALL gds.alpha.collapsePath.mutate('proj',
+CALL gds.beta.collapsePath.mutate('proj',
   {
-    relationshipTypes: ['HAD_ACTOR', 'ACTED_IN'],
+    pathTemplates: [['HAD_ACTOR', 'ACTED_IN']],
     allowSelfLoops: false,
     mutateRelationshipType: 'SHARES_ACTOR_WITH'
   }
@@ -188,7 +188,7 @@ The following command will train the pipeline. This process will
 ----
 CALL gds.beta.pipeline.nodeClassification.train('proj', {
   pipeline: 'pipe',
-  nodeLabels: ['TrainMovie'],
+  targetNodeLabels: ['TrainMovie'],
   modelName: 'nc-pipeline-model',
   targetProperty: 'cls',
   randomSeed: 7474,

--- a/asciidoc/courses/graph-data-science-fundamentals/modules/2-machine-learning-procedures/lessons/4-link-prediction/lesson.adoc
+++ b/asciidoc/courses/graph-data-science-fundamentals/modules/2-machine-learning-procedures/lessons/4-link-prediction/lesson.adoc
@@ -49,8 +49,8 @@ CALL gds.graph.project('proj',
 );
 
 //collapse path utility for relationship aggregation - no weight property
-CALL gds.alpha.collapsePath.mutate('proj',{
-    relationshipTypes: ['ACTED_IN', 'HAS_ACTOR'],
+CALL gds.beta.collapsePath.mutate('proj',{
+    pathTemplates: [['ACTED_IN', 'HAS_ACTOR']],
     allowSelfLoops: false,
     mutateRelationshipType: 'ACTED_WITH'
 });
@@ -172,6 +172,7 @@ The following command will train the pipeline. This process will:
 CALL gds.beta.pipeline.linkPrediction.train('proj', {
     pipeline: 'pipe',
     modelName: 'lp-pipeline-model',
+    targetRelationshipType: 'ACTED_WITH', 
     randomSeed: 7474 //usually a good idea to set a random seed for reproducibility.
 }) YIELD modelInfo
 RETURN


### PR DESCRIPTION
Updates based on Neo4j GDS v2.2 in two lessons:
-   courses/asciidoc/courses/graph-data-science-fundamentals/modules/2-machine-learning-procedures/lessons/3-node-classification/lesson.adoc
-  courses/asciidoc/courses/graph-data-science-fundamentals/modules/2-machine-learning-procedures/lessons/4-link-prediction/lesson.adoc