### PR TITLE
Cypher Fundamentals 2-9 typo

### DIFF
--- a/asciidoc/courses/cypher-fundamentals/modules/2-writing/lessons/9-delete/lesson.adoc
+++ b/asciidoc/courses/cypher-fundamentals/modules/2-writing/lessons/9-delete/lesson.adoc
@@ -152,7 +152,7 @@ RETURN p
 ----
 
 The Jane Doe node has two labels, Person and Developer. You can use a `MATCH` to find that node.
-Note that you could have specified `MATCH (p:Developer {name: 'Jane Doe'})` or `MATCH (p:Person:Developerr {name: 'Jane Doe'})` to find the same node.
+Note that you could have specified `MATCH (p:Developer {name: 'Jane Doe'})` or `MATCH (p:Person:Developer {name: 'Jane Doe'})` to find the same node.
 Once we have a reference to that node, we can remove the label with the `REMOVE` clause.
 
 And finally, delete the Jane Doe node by running this code:


### PR DESCRIPTION
Resolves a small typo, just changed `Developerr` to `Developer` for the node type.