### PR TITLE
change to v7 data importer

### DIFF
--- a/asciidoc/courses/importing-data/includes/importer-notice.adoc
+++ b/asciidoc/courses/importing-data/includes/importer-notice.adoc
@@ -1,8 +1,10 @@
-Neo4j Data Importer has launched but new releases are published frequently.
+Neo4j Data Importer Early Access is evolving rapidly.
 
-The latest version of Data Importer is here:
+There are two URLs for launching the **latest** version of Neo4j Data Importer:
 
-https://data-importer.neo4j.io/versions/latest/
+* For connecting to a remote DBMS: https://data-importer.neo4j.io/?acceptTerms=true
+* For connecting to local or remote DBMSs: https://data-importer.graphapp.io/?acceptTerms=true
 
-While the essence of the product remains the same, the UI will look different in a few places from what you see in this course.
-When following along don’t be too surprised if the latest product looks different in a few places or ways of displaying information have changed or are different.
+In this course we use the neo4j.io Version 0.7.0 of Neo4j Data Importer since we use a Neo4j Sandbox instance for this course.
+
+While the essence of the product remains the same, the UI may look different as the versions of the product evolve.

--- a/asciidoc/courses/importing-data/includes/importer-notice.adoc
+++ b/asciidoc/courses/importing-data/includes/importer-notice.adoc
@@ -4,7 +4,7 @@ Here are the URLs for launching the **latest** version of Neo4j Data Importer:
 
 * For connecting to a remote DBMS: https://data-importer.neo4j.io/?acceptTerms=true
 * For connecting to a remote DBMS: https://data-importer.graphapp.io/?acceptTerms=true
-* For connecting to local DBMS: https://data-importer.graphapp.io/?acceptTerms=true
+* For connecting to local DBMS: http://data-importer.graphapp.io/?acceptTerms=true
 
 In this course we use the neo4j.io Version 0.7.0 of Neo4j Data Importer since we use a Neo4j Sandbox instance for this course.
 

--- a/asciidoc/courses/importing-data/includes/importer-notice.adoc
+++ b/asciidoc/courses/importing-data/includes/importer-notice.adoc
@@ -1,9 +1,10 @@
 Neo4j Data Importer Early Access is evolving rapidly.
 
-There are two URLs for launching the **latest** version of Neo4j Data Importer:
+Here are the URLs for launching the **latest** version of Neo4j Data Importer:
 
 * For connecting to a remote DBMS: https://data-importer.neo4j.io/?acceptTerms=true
-* For connecting to local or remote DBMSs: https://data-importer.graphapp.io/?acceptTerms=true
+* For connecting to a remote DBMS: https://data-importer.graphapp.io/?acceptTerms=true
+* For connecting to local DBMS: https://data-importer.graphapp.io/?acceptTerms=true
 
 In this course we use the neo4j.io Version 0.7.0 of Neo4j Data Importer since we use a Neo4j Sandbox instance for this course.
 

--- a/asciidoc/courses/importing-data/includes/importer-notice.adoc
+++ b/asciidoc/courses/importing-data/includes/importer-notice.adoc
@@ -1,7 +1,8 @@
-Neo4j Data Importer has launched in Beta and is evolving rapidly.
+Neo4j Data Importer has launched but new releases are published frequently.
+
 The latest version of Data Importer is here:
 
 https://data-importer.neo4j.io/versions/latest/
 
-While the essence of the product remains the same, the UI will look different in a few places.
-When following along don’t be too surprised if the product looks different in a few places or ways of displaying information have changed or are different.
+While the essence of the product remains the same, the UI will look different in a few places from what you see in this course.
+When following along don’t be too surprised if the latest product looks different in a few places or ways of displaying information have changed or are different.

--- a/asciidoc/courses/importing-data/modules/2-using-data-importer/lessons/1-overview/lesson.adoc
+++ b/asciidoc/courses/importing-data/modules/2-using-data-importer/lessons/1-overview/lesson.adoc
@@ -12,17 +12,7 @@ video::-QxpQ8FeD9M[youtube,width=560,height=315]
 [.transcript]
 == What is the Neo4j Data Importer?
 
-For this course, we use Neo4j Data Importer 7.0.
-The Neo4j Data Importer can be found link:https://data-importer.neo4j.io/versions/0.7.0/?acceptTerms=true[here^]:
-
-[NOTE]
-.Latest Neo4j Data Importer
-====
-include::../../../../includes/importer-notice.adoc[]
-====
-
-
-It is a graph app the allows you to import CSV files from your local system into the graph. With this graph app, you can examine the CSV file headers, and map them to nodes and relationships in a Neo4j graph.
+Neo4j Data Importer is a graph app the allows you to import CSV files from your local system into the graph. With this graph app, you can examine the CSV file headers, and map them to nodes and relationships in a Neo4j graph.
 You connect to a running Neo4j DBMS to perform the import.
 The benefit of the Data Importer is that you need not know Cypher to load the data.
 
@@ -31,6 +21,18 @@ It is useful for loading small to medium CSV files that contain fewer that 1M ro
 Data that is imported into the graph can be interpreted as string, integer, float, datetime, or boolean data.
 If a field in a row needs to be stored in the graph as a list, it will be by default stored in the graph as a string and you will need to post-process the graph after the import.
 You will learn about this later in this course.
+
+For this course, we use Neo4j Data Importer Version 0.7.0.
+This version of Neo4j Data Importer can be found link:https://data-importer.neo4j.io/versions/0.7.0/?acceptTerms=true[here^]
+
+[NOTE]
+.Neo4j Data Importer Versions
+====
+include::../../../../includes/importer-notice.adoc[]
+====
+
+
+
 
 
 === Requirements for using the Data Importer
@@ -56,12 +58,16 @@ You will examine the files and make sure they have headers and are "clean", as y
 
 ==== Step 2: Opening the Neo4j Data Importer
 
-You will open the Data Importer app from any Web browser using this URL: https://data-importer.graphapp.io/?acceptTerms=true
+In the next Challenge, you will open the Data Importer app from any Web browser using this URL: https://data-importer.neo4j.io/versions/0.7.0/?acceptTerms=true
+
+[NOTE]
+The Neo4j Data Importer UI is evolving.
+You may see minor differences in the UI if you use a different version of Neo4j Data Importer.
 
 image::{repository-raw}/{path}/images/data-importer.png[Neo4j Data Importer,width=400,align=center]
 
 When you open Data Importer, it asks you to connect to a running DBMS.
-This is where you provide the **WebSocket Bolt URL** and **password** for the sandbox instance used for this course.
+This is where you provide the WebSocket Bolt URL and password for the sandbox instance used for this course.
 
 image::{repository-raw}/{path}/images/connect.png[Connect to Sandbox,width=400,align=center]
 

--- a/asciidoc/courses/importing-data/modules/2-using-data-importer/lessons/1-overview/lesson.adoc
+++ b/asciidoc/courses/importing-data/modules/2-using-data-importer/lessons/1-overview/lesson.adoc
@@ -12,10 +12,11 @@ video::-QxpQ8FeD9M[youtube,width=560,height=315]
 [.transcript]
 == What is the Neo4j Data Importer?
 
-The Neo4j Data Importer can be found link:https://data-importer.graphapp.io/?acceptTerms=true[here^]:
+For this course, we use Neo4j Data Importer 7.0.
+The Neo4j Data Importer can be found link:https://data-importer.neo4j.io/versions/0.7.0/?acceptTerms=true[here^]:
 
 [NOTE]
-.Neo4j Data Importer Beta
+.Latest Neo4j Data Importer
 ====
 include::../../../../includes/importer-notice.adoc[]
 ====
@@ -57,14 +58,10 @@ You will examine the files and make sure they have headers and are "clean", as y
 
 You will open the Data Importer app from any Web browser using this URL: https://data-importer.graphapp.io/?acceptTerms=true
 
-[NOTE]
-The Neo4j Data Importer UI is evolving.
-You may see minor differences in the UI.
-
 image::{repository-raw}/{path}/images/data-importer.png[Neo4j Data Importer,width=400,align=center]
 
 When you open Data Importer, it asks you to connect to a running DBMS.
-This is where you provide the WebSocket Bolt URL and password for the sandbox instance used for this course.
+This is where you provide the **WebSocket Bolt URL** and **password** for the sandbox instance used for this course.
 
 image::{repository-raw}/{path}/images/connect.png[Connect to Sandbox,width=400,align=center]
 

--- a/asciidoc/courses/importing-data/modules/2-using-data-importer/lessons/2-c-importing-CSV/lesson.adoc
+++ b/asciidoc/courses/importing-data/modules/2-using-data-importer/lessons/2-c-importing-CSV/lesson.adoc
@@ -41,7 +41,7 @@ Uncompress this file. You should have these files:
 
 == Step 2: Open the Data Importer
 
-In a Web browser window, open the https://data-importer.graphapp.io/?acceptTerms=true[Neo4j Data Importer^]
+In a Web browser window, open the https://data-importer.neo4j.io/versions/0.7.0/?acceptTerms=true[Neo4j Data Importer^]
 
 When you open Data Importer, you must connect to the sandbox instance for this course.
 Before you import the data, you must have the information about the Neo4j instance you will be importing into.
@@ -65,15 +65,12 @@ image::{repository-raw}/{path}/images/data-importer-c.png[Neo4j Data Importer,wi
 
 [NOTE]
 --
-The Neo4j Data Importer may have changed since this course was published.
-You may see minor differences in the UI.
-
 If you see nodes and relationships in the Graph Model pane, you should select all of them and delete them so you can start with a new mapping.
 Alternatively, you can select the "..." to the right of **Run Import** button and select **Clear all**.
 
 image::{repository-raw}/{path}/images/data-importer-clear-all.png[Neo4j Data Importer,width=600,align=center]
-
 --
+
 == Step 3: Load the CSV files into the Data Importer
 
 In the left *Files* panel, add the five CSV files you uncompressed in *Step 1*.

--- a/asciidoc/courses/importing-data/modules/2-using-data-importer/lessons/2-c-importing-CSV/lesson.adoc
+++ b/asciidoc/courses/importing-data/modules/2-using-data-importer/lessons/2-c-importing-CSV/lesson.adoc
@@ -69,8 +69,8 @@ If you see nodes and relationships in the Graph Model pane, you should select al
 Alternatively, you can select the "..." to the right of **Run Import** button and select **Clear all**.
 
 image::{repository-raw}/{path}/images/data-importer-clear-all.png[Neo4j Data Importer,width=600,align=center]
---
 
+--
 == Step 3: Load the CSV files into the Data Importer
 
 In the left *Files* panel, add the five CSV files you uncompressed in *Step 1*.


### PR DESCRIPTION
Modified all images to show data importer 7.0

Specified https://data-importer.neo4j.io/versions/0.7.0/?acceptTerms=true for the course so the images will always match what the user sees.

Modified section about getting latest.

Note: video does not need to change as it is the same behavior as v7.0 and it should not confuse the viewer