### PR TITLE
Point index addition - do not merge until after the reco db changes PR has been merged

### DIFF
--- a/asciidoc/courses/cypher-indexes-constraints/modules/1-introduction/lessons/01-overview/lesson.adoc
+++ b/asciidoc/courses/cypher-indexes-constraints/modules/1-introduction/lessons/01-overview/lesson.adoc
@@ -51,8 +51,6 @@ This type of index is called a Composite index.
 --
 Full-text indexes are used differently from the other types of indexes in Neo4j.
 Full-text indexes will be covered separately in a later module.
-//Elaine: TBD Point indexes
-This course does not currently cover POINT indexes
 --
 
 == Check your understanding

--- a/asciidoc/courses/cypher-indexes-constraints/modules/1-introduction/lessons/01-overview/questions/1-select-answer.adoc
+++ b/asciidoc/courses/cypher-indexes-constraints/modules/1-introduction/lessons/01-overview/questions/1-select-answer.adoc
@@ -4,21 +4,22 @@
 
 Suppose you need to create an index that will support fast lookups during a query.
 
-What are some of the types of indexes can you use? (select all that apply)
+What are the types of indexes can you use? (select all that apply)
 
 * [x] TEXT
 * [x] Full-text
 * [x] RANGE
 * [ ] Hash
+* [x] POINT
 
 [TIP,role=hint]
 .Hint
 ====
-Three of these indexes types are supported in Neo4j.
+Four of these indexes types are supported in Neo4j.
 ====
 
 [TIP,role=solution]
 .Solution
 ====
-The correct answers are **TEXT**, **full-text**, and **RANGE**
+The correct answers are **TEXT**, , **POINT**, **full-text**, and **RANGE**
 ====

--- a/asciidoc/courses/cypher-indexes-constraints/modules/3-indexes/lessons/01-index-overview/lesson.adoc
+++ b/asciidoc/courses/cypher-indexes-constraints/modules/3-indexes/lessons/01-index-overview/lesson.adoc
@@ -7,6 +7,7 @@ video::hp-m572Z8lk[youtube,width=560,height=315]
 
 //https://youtu.be/hp-m572Z8lk
 
+// video redo required due to POINT index addition to course
 
 [.transcript]
 
@@ -124,12 +125,27 @@ RETURN p
 ----
 
 
-[NOTE]
-.POINT indexes
---
-This course does not currently cover POINT indexes.
-You can read about them in the link:https://neo4j.com/docs/cypher-manual/current/indexes-for-search-performance[Neo4j Cypher Manual^].
---
+=== POINT indexes
+
+A point tyoe for a node or relationship property represents spatial data (coordinates). The data in the point type property will have 2 or 3 numeric values, depending on which coordinate system you use for your spatial data.
+You can read about point types  in the link:https://neo4j.com/docs/cypher-manual/current/syntax/spatial/[Cypher Reference Manual^].
+You can read about POINT indexes in the link:https://neo4j.com/docs/cypher-manual/current/indexes-for-search-performance[Neo4j Cypher Manual^].
+
+A point property type contains a set of numeric values representing a location. For example, in our graph used for this course, the Person.bornLocation is a point data tyoe.
+Execute this code to see what the property values appear as:
+
+[source,cypher]
+----
+MATCH (p:Person)
+WHERE p.bornLocation IS NOT NULL
+RETURN p.name, p.bornIn, p.bornLocation LIMIT 10
+----
+
+If the p.bornLocation property has a POINT index, you can use it to quickly look up nodes that have the same bornLocation value.
+
+You will have an opportunity to create and use a POINT index later in this module.
+
+You can read about POINT indexes in the link:https://neo4j.com/docs/cypher-manual/current/indexes-for-search-performance[Neo4j Cypher Manual^].
 
 == Check your understanding
 

--- a/asciidoc/courses/cypher-indexes-constraints/modules/3-indexes/lessons/09-point-index/lesson.adoc
+++ b/asciidoc/courses/cypher-indexes-constraints/modules/3-indexes/lessons/09-point-index/lesson.adoc
@@ -2,15 +2,11 @@
 :type: quiz
 :sandbox: true
 
-////
+
 [.video]
-video::Y9YrGJMJf1A[youtube,width=560,height=315]
+video::xNbhUB9QkXY[youtube,width=560,height=315]
 
-//https://youtu.be/Y9YrGJMJf1A
-
-need a new video
-////
-
+//https://youtu.be/xNbhUB9QkXY
 
 [.transcript]
 

--- a/asciidoc/courses/cypher-indexes-constraints/modules/3-indexes/lessons/09-point-index/lesson.adoc
+++ b/asciidoc/courses/cypher-indexes-constraints/modules/3-indexes/lessons/09-point-index/lesson.adoc
@@ -1,0 +1,123 @@
+= Creating POINT Indexes
+:type: quiz
+:sandbox: true
+
+////
+[.video]
+video::Y9YrGJMJf1A[youtube,width=560,height=315]
+
+//https://youtu.be/Y9YrGJMJf1A
+
+need a new video
+////
+
+
+[.transcript]
+
+////
+IMPORTANT to do after the reco db changes are merged
+Need to change the next description in this Challenge
+ asciidoc/courses/cypher-indexes-constraints/modules/3-indexes/lessons/08-c-create-text-index/lesson.adoc
+ to point to this lesson.
+////
+
+== POINT Indexes in Neo4j
+
+A POINT index is designed for single properties of nodes or relationships that are of type point.
+It is used to look up a value where the lookup is done with a value in the same spatial coordinate system.
+
+=== Syntax for creating a POINT index for node property
+
+Here is the syntax for creating a POINT index for a single property of a node:
+
+[source,cypher,role=nocopy noplay]
+----
+CREATE POINT INDEX <index_name> IF NOT EXISTS
+FOR (x:<node_label>)
+ON x.<property_key>
+----
+
+You specify the name of the index, the node label it will be associated with, and the name of the property.
+
+* If an index already exists in the graph with the same name, no index is created.
+* If an index does not exist in the graph with the same name:
+** No index is created if there already is a POINT index for that node label and property key.
+** Otherwise, the POINT index is created.
+
+[NOTE]
+For the point property used to create the index, all properties must use the same spatial coordinate system.
+
+=== Creating and using the POINT index
+
+Here is a query where we want to return all people who were born in the same location as Diane Keaton.
+Execute this query:
+
+[source,cypher]
+----
+PROFILE MATCH (p:Person)
+WHERE p.name CONTAINS 'Diane Keaton'
+WITH p.bornLocation as loc
+MATCH (p2:Person)
+WHERE p2.bornLocation = loc
+RETURN p2.name, p2.bornIn, p2.bornLocation
+----
+
+Your graph should already have a RANGE index on the name property of Person nodes that it uses for this query.
+By default, the graph engine can only use a single index for a query.
+If we want to find all people who where born in the same location as Diane Keaton, we should execute a separate query with the bornLocation value returned.
+
+Execute this query that provides the bornLocation value for Diane Keaton:
+
+[source,cypher]
+----
+PROFILE MATCH (p:Person)
+WHERE p.bornLocation = point({srid:4326, x:-118.4166991, y:34.2013928})
+RETURN p.name, p.bornIn, p.bornLocation
+----
+
+Notice that this query requires 51621 db hits.
+
+We want to improve the performance of this query. We add a POINT index to the bornLocation property of Person nodes.
+Execute this code to create the index:
+
+[source,cypher]
+----
+CREATE POINT INDEX Person_bornLocation_point IF NOT EXISTS
+FOR (x:Person)
+ON (x.bornLocation)
+----
+
+You can list the indexes to see that there is indeed a POINT index on the Person.bornLocation node property.
+
+Now execute the query again:
+
+[source,cypher]
+----
+PROFILE MATCH (p:Person)
+WHERE p.bornLocation = point({srid:4326, x:-118.4166991, y:34.2013928})
+RETURN p.name, p.bornIn, p.bornLocation
+----
+
+With the index, the number of db hits is reduced to 1493.
+
+Here is another example where the POINT index is used to determine the number of people that were born in a location less than 50000 meters from Los Angeles.
+Here we use the spatial `distance()` function.
+Execute this query:
+
+[source,cypher]
+----
+PROFILE MATCH (p:Person)
+WHERE point.distance(p.bornLocation,point({srid:4326, x:-118.4166991, y:34.2013928})) < 50000
+RETURN p.name, p.bornIn, p.bornLocation
+----
+
+== Check your understanding
+
+include::questions/1-complete-query.adoc[leveloffset=+1]
+include::questions/2-select-answer.adoc[leveloffset=+1]
+
+[.summary]
+== Summary
+
+In this lesson, you learned how to create a POINT index for a property.
+In the next Module, you will learn about creating full-text indexes.

--- a/asciidoc/courses/cypher-indexes-constraints/modules/3-indexes/lessons/09-point-index/questions/1-complete-query.adoc
+++ b/asciidoc/courses/cypher-indexes-constraints/modules/3-indexes/lessons/09-point-index/questions/1-complete-query.adoc
@@ -1,0 +1,26 @@
+[.question]
+= 1. Creating and using a POINT index
+
+Suppose we have a graph that contains Company nodes. One of the properties of a Company node is location.
+We want to be able to optimize queries that test distances between companies by creating a POINT index on the Company.location property.
+
+What conditions must be met in our graph to be able to create and use a POINT index? (Select all that apply)
+
+* [ ] All Company.location properties must have a value.
+* [ ] All Company.location property values must be of type double.
+* [x] All Company.location property values must be of type point.
+* [x] All Company.location property values must use the same spatial coordinate system.
+
+[TIP,role=hint]
+.Hint
+====
+What is values are required to create a property of type point?
+====
+
+[TIP,role=solution]
+.Solution
+====
+
+In order to create and use a POINT index on the Company.location property, the property need not exist for all nodes, but if it does, it must be of type point and every value used for this property for all nodes must use the same spatial coordinate system.
+
+====

--- a/asciidoc/courses/cypher-indexes-constraints/modules/3-indexes/lessons/09-point-index/questions/2-select-answer.adoc
+++ b/asciidoc/courses/cypher-indexes-constraints/modules/3-indexes/lessons/09-point-index/questions/2-select-answer.adoc
@@ -1,0 +1,29 @@
+[.question]
+= 2. Creating a POINT index
+
+
+Suppose we have a graph that contains Company nodes. One of the properties of a Company node is location.
+The values for the Company.location are of type point and these values use the WGS-84 coordinate system.
+
+What is the correct statement to create this POINT index?
+
+* [ ] `CREATE SPATIAL INDEX Company_location_point IF NOT EXISTS FOR (x:Company) ON (x.location)`
+* [ ] `CREATE SPAIIAL INDEX Company_location_point IF NOT EXISTS ON (Company.location) USING COORDINATE WGS-84`
+* [x] `CREATE POINT INDEX Company_location_point IF NOT EXISTS FOR (x:Company) ON (x.location)`
+* [ ] `CREATE POINT INDEX Company_location_point  IF NOT EXISTS ON (Company.location) USING COORDINATE WGS-84`
+
+[TIP,role=hint]
+.Hint
+====
+You are creating a POINT index and you need not specify the coordinate system when you create the index, but all property values must use the same coordinate system.
+
+====
+
+[TIP,role=solution]
+.Solution
+====
+
+The correct code for creating the POINT index is:
+
+`CREATE POINT INDEX Company_location_point IF NOT EXISTS FOR (x:Company) ON (x.location)`
+====

--- a/asciidoc/courses/cypher-indexes-constraints/modules/3-indexes/lessons/09-point-index/reset.cypher
+++ b/asciidoc/courses/cypher-indexes-constraints/modules/3-indexes/lessons/09-point-index/reset.cypher
@@ -1,0 +1,18 @@
+// drop all indexes and constraints
+call apoc.schema.assert({},{},true);
+// create uniqueness constraints
+CREATE CONSTRAINT Movie_movieId_unique IF NOT EXISTS FOR (x:Movie) REQUIRE x.movieId IS UNIQUE;
+CREATE CONSTRAINT Person_tmdbId_unique IF NOT EXISTS FOR (x:Person) REQUIRE x.tmdbId IS UNIQUE;
+CREATE CONSTRAINT User_userId_unique IF NOT EXISTS FOR (x:User) REQUIRE x.userId IS UNIQUE;
+CREATE CONSTRAINT Genre_name_unique IF NOT EXISTS FOR (x:Genre) REQUIRE x.name IS UNIQUE;
+CREATE CONSTRAINT Person_name_exists IF NOT EXISTS FOR (x:Person) REQUIRE x.name IS NOT NULL;
+CREATE CONSTRAINT Movie_title_exists IF NOT EXISTS FOR (x:Movie) REQUIRE x.title IS NOT NULL;
+CREATE CONSTRAINT User_name_exists IF NOT EXISTS FOR (x:User) REQUIRE x.name IS NOT NULL;
+CREATE CONSTRAINT Movie_imdbId_nodekey IF NOT EXISTS FOR (x:Movie) REQUIRE x.imdbId IS NODE KEY;
+CREATE INDEX Movie_title IF NOT EXISTS FOR (x:Movie) ON (x.title);
+CREATE INDEX Person_name IF NOT EXISTS FOR (x:Person) ON (x.name);
+CREATE INDEX RATED_rating IF NOT EXISTS FOR ()-[x:RATED]-() ON (x.rating);
+CREATE INDEX Movie_year_runtime IF NOT EXISTS FOR (x:Movie) ON (x.year, x.runtime);
+CREATE INDEX Movie_year_imdbRating IF NOT EXISTS FOR (x:Movie) ON (x.year, x.imdbRating);
+CREATE  INDEX RATED_ratingY IF NOT EXISTS FOR ()-[x:RATED]-() ON (x.ratingY);
+CREATE  TEXT INDEX RATED_ratingY_text IF NOT EXISTS FOR ()-[x:RATED]-() ON (x.ratingY)

--- a/asciidoc/courses/cypher-indexes-constraints/modules/3-indexes/module.adoc
+++ b/asciidoc/courses/cypher-indexes-constraints/modules/3-indexes/module.adoc
@@ -17,6 +17,7 @@ In this module, you will:
 * Create an index on a relationship property.
 * Create a composite index on a set of node properties.
 * Create a TEXT index.
+* Create a POINT index.
 * Manage indexes in the graph.
 
 == Resources


### PR DESCRIPTION
This PR adds the POINT lesson to the indexes and constraints course.

It should not be merged until after the reco db changes PR has been merged.

A comment has beed added to the lesson.adoc that the summary for the previous Challenge needs to now point to this lesson. I did not make that change yet because that Challenge is part of the reco db change PR.