### PR TITLE
fix query

### DIFF
--- a/asciidoc/courses/llm-vectors-unstructured/modules/3-unstructured-data/lessons/6-extract-topics/lesson.adoc
+++ b/asciidoc/courses/llm-vectors-unstructured/modules/3-unstructured-data/lessons/6-extract-topics/lesson.adoc
@@ -106,7 +106,7 @@ You can list the topics and the number of lessons that mention them to understan
 [source, cypher]
 ----
 MATCH (t:Topic)<-[:MENTIONS]-(p:Paragraph)<-[:CONTAINS]-(l:Lesson)
-RETURN t.name, COUNT(DISTINCT(l)) as lessons
+RETURN t.name, COUNT(DISTINCT l) as lessons
 ORDER BY lessons DESC
 ----
 

--- a/asciidoc/courses/llm-vectors-unstructured/modules/3-unstructured-data/lessons/6-extract-topics/lesson.adoc
+++ b/asciidoc/courses/llm-vectors-unstructured/modules/3-unstructured-data/lessons/6-extract-topics/lesson.adoc
@@ -106,7 +106,7 @@ You can list the topics and the number of lessons that mention them to understan
 [source, cypher]
 ----
 MATCH (t:Topic)<-[:MENTIONS]-(p:Paragraph)<-[:CONTAINS]-(l:Lesson)
-RETURN t.name, COUNT(l) as lessons
+RETURN t.name, COUNT(DISTINCT(l)) as lessons
 ORDER BY lessons DESC
 ----
 


### PR DESCRIPTION
First of all, thanks for providing this great resource. While working through the code I found a small error in one of the examples:

needs to return distinct lessons, because there may be multiple matching paragraphs per lesson and we're interested in the number of matching lessons. query to illustrate:
```
MATCH (t:Topic)<-[:MENTIONS]-(p:Paragraph)<--(l:Lesson)
RETURN t.name, COUNT(p) AS paragraphs, COUNT(DISTINCT(l)) as lessons
ORDER BY lessons DESC
```