### PR TITLE
Updated table 'dataConfig' Description in table and fixed projection name

### DIFF
--- a/asciidoc/courses/gds-product-introduction/modules/2-graph-management/lessons/4-cypher-projection/lesson.adoc
+++ b/asciidoc/courses/gds-product-introduction/modules/2-graph-management/lessons/4-cypher-projection/lesson.adoc
@@ -41,7 +41,7 @@ A Cypher projection takes two mandatory arguments: `graphName` and `sourceNode`.
 | graphName         | no       | The name under which the graph is stored in the catalog.
 | sourceNode         | no       | The source node of the relationship. Must not be null.
 | targetNode | yes       | The target node of the relationship. The targetNode can be null (for example due to an OPTIONAL MATCH), in which case the source node is projected as an unconnected node.
-| dataConfig | yes       | The target node of the relationship. The targetNode can be null (for example due to an OPTIONAL MATCH), in which case the source node is projected as an unconnected node.
+| dataConfig | yes       | Properties and labels configuration for the source and target nodes as well as properties and type configuration for the relationship.
 | configuration     | yes      | Additional parameters to configure the projection.
 |===
 
@@ -91,7 +91,7 @@ Once the projection is created we can apply degree centrality like we did last l
 
 [source, cypher]
 ----
-CALL gds.degree.stream('proj-cypher',{relationshipWeightProperty: 'actedWithCount'})
+CALL gds.degree.stream('cypher-proj',{relationshipWeightProperty: 'actedWithCount'})
 YIELD nodeId, score
 RETURN gds.util.asNode(nodeId).name AS name, score
 ORDER BY score DESC LIMIT 10


### PR DESCRIPTION
Updated table 'dataConfig' Description in table using the Description defined in neo4j documentation page: https://neo4j.com/docs/graph-data-science/current/management-ops/graph-creation/graph-project-cypher-projection/#:~:text=Properties%20and%20labels%20configuration%20for%20the%20source%20and%20target%20nodes%20as%20well%20as%20properties%20and%20type%20configuration%20for%20the%20relationship. 

Fixed projection name in line 94 from 'proj-cypher' to 'cypher-proj' to match projection name defined in line 75.