### PR TITLE
app-go - added gitpod / local install instructions

### DIFF
--- a/asciidoc/courses/app-go/modules/1-driver/lessons/2-c-create-driver/lesson.adoc
+++ b/asciidoc/courses/app-go/modules/1-driver/lessons/2-c-create-driver/lesson.adoc
@@ -4,22 +4,59 @@
 :lab-file: pkg/challenges/create_driver/challenge.go
 :lab-solution: pkg/challenges/create_driver/solution/solution.go
 :lab: {repository-blob}/main/{lab-file}
+:branch: go-patch
 
 Your challenge is to add a new driver instance to an existing file with the connection details provided.
 Once you have created the driver, you will need to open a new session and execute a Cypher statement to find the director of the movie **Toy Story**.
 
 
-link:./lab[Open Challenge in an Online IDE →^, role=btn]
+We have created a link:{repository-link}[repository^] for this course.
+It contains the starter code and resources you need.
+
+A Neo4j Sandbox instance has also been created for you to use during this course.
+
+== Get the code
+
+You can use link:https://gitpod.io[Gitpod^] as an online IDE and workspace for this workshop.
+It will automatically clone the workshop repository and set up your environment.
+
+lab::Open `Gitpod workspace`[]
+
+[NOTE]
+You will need to login with a Github account.
+
+Alternatively, you can clone the repository and set up the environment yourself.
+
+[%collapsible]
+.Develop on your local machine
+====
+You will need link:https://go.dev/doc/install[Go] installed and the ability to install the Neo4j driver using `go get`.
+
+Clone the link:{repository-link}[https://github.com/neo4j-graphacademy/app-go] repository:
+
+[source,bash]
+----
+git clone https://github.com/neo4j-graphacademy/app-go
+----
+
+Setup environment variables for the connection to the Neo4j Sandbox instance:
+
+NEO4J_URI:: [copy]#bolt://{sandbox-ip}:{sandbox-boltPort}#
+NEO4J_USERNAME:: [copy]#{sandbox-username}#
+NEO4J_PASSWORD:: [copy]#{sandbox-password}#
+====
 
 == Steps
 
-1. Install the Neo4j Go Driver in the integrated terminal window
+Open the `pkg/challenges/create_driver/challenge.go` file:
+
+. Install the Neo4j Go Driver in the integrated terminal window
 +
 include::{repository-raw}/main/README.adoc[tag=install]
 
-2. Import the `github.com/neo4j/neo4j-go-driver/v5/neo4j` symbol and use the `neo4j` object to create a new instance of the Driver with `Uri`, `Username` and `Password` credentials provided obtained using the `GetNeo4jCredentials()` method
+. Import the `github.com/neo4j/neo4j-go-driver/v5/neo4j` symbol and use the `neo4j` object to create a new instance of the Driver with `Uri`, `Username` and `Password` credentials provided obtained using the `GetNeo4jCredentials()` method
 
-3. Once you have created the Driver, open a new session and execute the following `cypher` statement using the `params` map.
+. Once you have created the Driver, open a new session and execute the following `cypher` statement using the `params` map.
 +
 .Find the Director
 [source,cypher]
@@ -28,7 +65,7 @@ MATCH (p:Person)-[:DIRECTED]->(:Movie {title: $title})
 RETURN p.name AS Director
 ----
 
-4. To find the answer, click the Debug icon to the left of the IDE window and run **Create Driver Challenge** task, or use the integrated terminal window to run the following command: +
+. To find the answer, click the Debug icon to the left of the IDE window and run **Create Driver Challenge** task, or use the integrated terminal window to run the following command: +
 +
 .Run The Challenge
 [source,sh,subs=attributes+]
@@ -36,7 +73,7 @@ RETURN p.name AS Director
 go run {lab-file}
 ----
 
-5. Once you have the result, copy and paste it into the text box below and click **Check Answer**.
+. Once you have the result, copy and paste it into the text box below and click **Check Answer**.
 
 
 == Your Answer

--- a/asciidoc/courses/app-go/modules/1-driver/lessons/8-c-writing-data/lesson.adoc
+++ b/asciidoc/courses/app-go/modules/1-driver/lessons/8-c-writing-data/lesson.adoc
@@ -7,9 +7,9 @@
 
 Your challenge is to modify another pre-written file to add yourself as an actor in The Matrix.
 
-link:./lab[Open Challenge in an Online IDE →^, role=btn]
-
 == Steps
+
+Open the `pkg/challenges/write/challenge.go` file:
 
 1. Update the `params` object to use your name.
 This step isn't strictly required, just a bit of fun.


### PR DESCRIPTION
Had a community post about being confused with the `app-go` instructions. Added some additional context re gitpod and how to install locally.