### PR TITLE
Dockercompose - remove command to run the app

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -62,12 +62,6 @@ services:
     depends_on:
       neo4j:
         condition: service_healthy
-    command:
-      - /bin/sh
-      - -c
-      - |
-        npm install nodemon
-        npm run dev
   # sync:
   #   build: .
   #   networks:


### PR DESCRIPTION
The dockercompose includes a command to run the application - this isnt needed and causes the container to error as /bin/sh is unavailable.