### PR TITLE
Python Driver Course: Editorial Changes

### DIFF
--- a/asciidoc/courses/drivers-python/modules/1-driver/lessons/3-execute-query/lesson.adoc
+++ b/asciidoc/courses/drivers-python/modules/1-driver/lessons/3-execute-query/lesson.adoc
@@ -20,7 +20,7 @@ cypher = """
 MATCH (p:Person {name: $name})-[r:ACTED_IN]->(m:Movie) 
 RETURN m.title AS title, r.role AS role
 """
-name="Tom Hanks"
+name = "Tom Hanks"
 
 records, summary, keys = driver.execute_query( # <1>
     cypher,    # <2>

--- a/asciidoc/courses/drivers-python/modules/1-driver/lessons/3-execute-query/lesson.adoc
+++ b/asciidoc/courses/drivers-python/modules/1-driver/lessons/3-execute-query/lesson.adoc
@@ -55,8 +55,8 @@ The `execute_query()` method returns an a tuple containing three objects:
 
 [source,python]
 ----
-print(keys) # ['title', 'role']
-print(summary) # A summary of the query execution
+print(keys)  # ['title', 'role']
+print(summary)  # A summary of the query execution
 ----
 
 [.slide]
@@ -71,8 +71,8 @@ You can access any item in the `RETURN` clause using square brackets.
 # RETURN m.title AS title, r.role AS role
 
 for record in records:
-    print(record["title"]) # Toy Story
-    print(record["role"]) # "Woody"
+    print(record["title"])  # Toy Story
+    print(record["role"])  # "Woody"
 ----
 
 [.slide]
@@ -93,7 +93,7 @@ result = driver.execute_query(
     ]
 )
 
-print(result) # [Tom Hanks played Woody in Toy Story, ...]
+print(result)  # ['Tom Hanks played Woody in Toy Story', ...]
 ----
 
 
@@ -107,8 +107,8 @@ The `Result` class provides a `to_df()` method that can be used to transform the
 from neo4j import Result
 
 driver.execute_query(
-  cypher, 
-  result_transformer_=Result.to_df
+    cypher,
+    result_transformer_=Result.to_df
 )
 ----
 
@@ -125,8 +125,8 @@ This distributes your read queries across all cluster members.
 from neo4j import Result, RoutingControl 
 
 driver.execute_query(
-  cypher, result_transformer_=Result.to_df,
-  routing_=RoutingControl.READ # or simply "r"
+    cypher, result_transformer_=Result.to_df,
+    routing_=RoutingControl.READ  # or simply "r"
 )
 ----
 

--- a/asciidoc/courses/drivers-python/modules/2-handling-results/lessons/1-type-system/lesson.adoc
+++ b/asciidoc/courses/drivers-python/modules/2-handling-results/lessons/1-type-system/lesson.adoc
@@ -94,7 +94,7 @@ for record in records:
 .Working with Node Objects
 [source,python,role=ncopy,subs="attributes+",indent=0]
 ----
-    print(node.id)              # (1)
+    print(node.element_id)      # (1)
     print(node.labels)          # (2)
     print(node.items())         # (3)
 
@@ -112,7 +112,7 @@ for record in records:
 2. The `labels` property is a frozenset containing an array of labels attributed to the Node +
     eg. `['Person', 'Actor']`
 3. The `items()` method provides access to the node's properties as an iterable of all name-value pairs. +
-    eg. `{name: 'Tom Hanks', tmdbId: '31' }`
+    eg. `{name: 'Tom Hanks', tmdbId: '31'}`
 4. A single property can be retrieved by either using `[]` brackets or using the `get()` method.  The `get()` method also allows you to define a default property if none exists.
 
 ====
@@ -149,8 +149,8 @@ Relationships are returned as a `Relationship` object.
 2. `type` - Type of relationship (eg. `ACTED_IN`) 
 3. `items()` - Returns relationship properties as name-value pairs (eg. `{role: 'Woody'}`)
 4. Access properties using brackets `[]` or `get()` method
-5. `start_node` - ID of the starting node
-6. `end_node` - ID of the ending node
+5. `start_node` - `Node` object at the start of the relationship
+6. `end_node` - `Node` object at the end of the relationship
 ====
 
 [.slide.col-2]
@@ -176,10 +176,10 @@ A path is a sequence of nodes and relationships and is returned as a `Path` obje
 
 [.col]
 ====
-1. `start_node` - a Neo4j `Integer` representing the internal ID for the node at the start of the path
-2. `end_node` - a Neo4j `Integer` representing the internal ID for the node at the end of the path
-3. `len(path)` - A count of the number of relationships within the path
-4. `relationships` - An array of `Relationship` objects within the path.
+1. `start_node` - `Node` object at the start of the path
+2. `end_node` - `Node` object at the end of the path
+3. `len(path)` - The number of relationships within the path
+4. `relationships` - An tuple of `Relationship` objects within the path.
 
 [TIP]
 .Paths are iterable

--- a/asciidoc/courses/drivers-python/modules/2-handling-results/lessons/2c-accessing-graph-types/questions/1-node-property.adoc
+++ b/asciidoc/courses/drivers-python/modules/2-handling-results/lessons/2c-accessing-graph-types/questions/1-node-property.adoc
@@ -1,7 +1,7 @@
 [.question.select-in-source]
 = Accessing Node Properties
 
-Select the correct method to access the `name` property from a node with a default value of "Unknown" if the property doesn't exist.
+Select the correct method to access the `name` property from a node with a default value of `"Unknown"` if the property doesn't exist.
 
 [source,python,role=nocopy noplay]
 ----

--- a/asciidoc/courses/drivers-python/modules/2-handling-results/lessons/3-dates-and-times/lesson.adoc
+++ b/asciidoc/courses/drivers-python/modules/2-handling-results/lessons/3-dates-and-times/lesson.adoc
@@ -15,7 +15,7 @@ Temporal types in Neo4j are a combination of date, time and timezone elements.
 |Type |Description |Date? |Time? |Timezone?
 
 |`Date` |A tuple of Year, Month and Day |Y | |
-|`Time` |A point in time |Y |Y |
+|`Time` |The time of the day with a UTC offset |Y |Yfootnote:[`Time` only supports fixed UTC offsets.] |
 |`LocalTime` |A time without a timezone | |Y |
 |`DateTime` |A combination of Date and Time |Y |Y |Y
 |`LocalDateTime` |A combination of Date and Time without a timezone |Y |Y |
@@ -40,11 +40,11 @@ CREATE (e:Event {
   updatedAt: datetime()             // <3>
 })
 """, 
-  datetime=DateTime(
-    2024, 5, 15, 14, 30, 0, 
-    tzinfo=timezone(timedelta(hours=2))
-  ),  # <4>
-  dtstring="2024-05-15T14:30:00+02:00"
+    datetime=DateTime(
+        2024, 5, 15, 14, 30, 0, 
+        tzinfo=timezone(timedelta(hours=2))
+    ),  # <4>
+    dtstring="2024-05-15T14:30:00+02:00"
 )
 ----
 ====
@@ -81,10 +81,10 @@ RETURN date() as date, time() as time, datetime() as datetime, toString(datetime
 # Access the first record
 for record in records:
     # Automatic conversion to Python driver types
-    date = record["date"]         # neo4j.time.Date
-    time = record["time"]         # neo4j.time.Time
-    datetime = record["datetime"] # neo4j.time.DateTime
-    asString = record["asString"] # str
+    date = record["date"]           # neo4j.time.Date
+    time = record["time"]           # neo4j.time.Time
+    datetime = record["datetime"]   # neo4j.time.DateTime
+    as_string = record["asString"]  # str
 ----
 ====
 
@@ -99,9 +99,9 @@ for record in records:
 ----
 from neo4j.time import Duration, DateTime
 
-startsAt = DateTime.now() 
-eventLength = Duration(hours=1, minutes=30)
-endsAt = startsAt + eventLength 
+starts_at = DateTime.now() 
+event_length = Duration(hours=1, minutes=30)
+ends_at = startsAt + event_length
 
 driver.execute_query("""
 CREATE (e:Event {
@@ -110,7 +110,7 @@ CREATE (e:Event {
   interval: duration('P30M') // <2>
 })
 """,
-  startsAt=startsAt, endsAt=endsAt, eventLength=eventLength
+    startsAt=starts_at, endsAt=ends_at, eventLength=event_length
 )
 ----
 

--- a/asciidoc/courses/drivers-python/modules/2-handling-results/lessons/5-spatial-types/lesson.adoc
+++ b/asciidoc/courses/drivers-python/modules/2-handling-results/lessons/5-spatial-types/lesson.adoc
@@ -12,7 +12,7 @@
 ====
 Neo4j has built-in support for two-dimensional and three-dimensional spatial data types.
 These are referred to as **points**.
-A point may represent geographic coordinates (latitude, longitude) or Cartesian coordinates (x, y). 
+A point may represent geographic coordinates (longitude, latitude) or Cartesian coordinates (x, y). 
 
 Depending on the values used to create the point, it can either be a `CartesianPoint` or a `WGS84Point`.  If you specify three values, these are considered three dimensional points.  Otherwise, they are considered two dimensional points.
 
@@ -49,8 +49,8 @@ You can create a cartesian point by passing a tuple of values to the `CartesianP
 ----
 from neo4j.spatial import CartesianPoint
 
-twoD = CartesianPoint((x, y))
-threeD = CartesianPoint((x, y, z))
+two_d = CartesianPoint((x, y))
+three_d = CartesianPoint((x, y, z))
 ----
 
 The driver will convert `point` data types created with an x, y and z value to an instance of the `CartesianPoint` class.
@@ -72,7 +72,7 @@ point = records[0]["threeD"]
 print(point.x, point.y, point.z, point.srid) # 1.23, 4.56, 7.89, 9157
 
 # <2> Destructuring
-longitude, latitude, height = point
+x, y, z = point
 ----
 
 The values can be accessed using the `x`, `y` and `z` attributes `<1>` or by destructuring the point `<2>`.

--- a/asciidoc/courses/drivers-python/modules/3-in-production/lessons/1-transaction-management/lesson.adoc
+++ b/asciidoc/courses/drivers-python/modules/3-in-production/lessons/1-transaction-management/lesson.adoc
@@ -81,9 +81,9 @@ def create_person(tx, name, age): # <1>
 
 [.col]
 ====
-<1> The first argument to the transaction function is always a `Transaction` object. Any additional keyword arguments are passed to the transaction function.
+<1> The first argument to the transaction function is always a `ManagedTransaction` object. Any additional arguments are passed from the call to `Session.execute_read`/`Session.execute_write`.
 
-<2> The `run()` method on the `Transaction` object is called to execute a Cypher statement.
+<2> The `run()` method on the `ManagedTransaction` object is called to execute a Cypher statement.
 ====
 
 [.slide]
@@ -96,8 +96,8 @@ You can execute multiple queries within the same transaction function to ensure 
 def transfer_funds(tx, from_account, to_account, amount):
     # Deduct from first account
     tx.run(
-        "MATCH (a:Account {id: $from}) SET a.balance = a.balance - $amount", 
-        from=from_account, amount=amount
+        "MATCH (a:Account {id: $from_}) SET a.balance = a.balance - $amount", 
+        from_=from_account, amount=amount
     )
 
     # Add to second account
@@ -113,7 +113,7 @@ def transfer_funds(tx, from_account, to_account, amount):
 [WARNING]
 .Transaction state
 =====
-Transaction state is maintained in memory, so be mindful of running too many operations in a single transaction. Break up very large operations into smaller transactions when possible.
+Transaction state is maintained in the DBMS's memory, so be mindful of running too many operations in a single transaction. Break up very large operations into smaller transactions when possible.
 =====
 ====
 
@@ -122,13 +122,15 @@ Transaction state is maintained in memory, so be mindful of running too many ope
 
 [.col]
 ====
-The `execute_read()` and `execute_write()` methods return a `Result` object.
+The `ManagedTransaction.run()` method returns a `Result` object.
 
 The records contained within the result will be iterated over as soon as they are available.
 
 The result must be consumed within the transaction function.
 
-The `consume()` method discards any remaining records and returns a `Summary` object that can be used to access metadata about the transaction.
+The `consume()` method discards any remaining records and returns a `Summary` object that can be used to access metadata about the Cypher statement.
+
+Anything retruned by the transaction function will be retruend by `Session.execute_read`/`Session.execute_write` upon successfull execution.
 ====
 
 [.col]

--- a/asciidoc/courses/drivers-python/modules/3-in-production/lessons/3-error-handling/lesson.adoc
+++ b/asciidoc/courses/drivers-python/modules/3-in-production/lessons/3-error-handling/lesson.adoc
@@ -26,7 +26,7 @@ Exceptions related to the driver and its connection are subclasses of `DriverErr
 [.slide]
 == Handling errors
 
-Any errors raised by the driver will have `code` and `message` properties that describe the error.
+Any errors raised by the DBMS (`Neo4jError`) will have `code` and `message` properties that describe the error.
 
 [source,python]
 ----


### PR DESCRIPTION
Feel free to pick and choose from these suggestions as you see fit. If you have questions about why I suggested to change certain things, don't hesitate to reach out. Thanks for keeping this great learning resource going :heart: 

Further points for dicussion:
 * You're showing off `relationship.id` whereas for nodes you show `node.element_id`. Any good reason?
   * Side note: maybe it's actually best not to show either of them. They are tricky to use correctly as their lifetime/validity is only guaranteed to last a single transaction.
 * The course mentions `duration.between` and `point.distance` (the latter with an example following). At least in the first instance, I think it's not evident that those are Cypher functions which don't exist in the driver.
 * Somewhere, the course states
   > Specifying a database
   > 
   > In a multi-database instance, you can specify the database to use when creating a session using the database parameter.

   Generally, we recommend to always specify the database name when available. This often yields better performance.  
  To that extend it might make sense to adjust the examples. Not sure.