### PR TITLE
Genai courses golive

### DIFF
--- a/asciidoc/courses/app-spring-data/modules/6-next-steps/lessons/1-sdn-resources/lesson.adoc
+++ b/asciidoc/courses/app-spring-data/modules/6-next-steps/lessons/1-sdn-resources/lesson.adoc
@@ -20,7 +20,7 @@ Learn more about Neo4j:
 * https://neo4j.com/developer/[Neo4j Developer Hub^] - developer resources, including documentation, guides, integrations, and more
 * Graphacademy free, online courses:
 ** https://graphacademy.neo4j.com/categories/cypher/[Cypher courses^] - Intermediate queries, aggregations, indexes/constraints, and import data
-** https://graphacademy.neo4j.com/courses/llm-fundamentals/[LLM Fundamentals^] - get an introduction to Generative AI with Neo4j in this course
+** https://graphacademy.neo4j.com/courses/genai-fundamentals/[LLM Fundamentals^] - get an introduction to Generative AI with Neo4j in this course
 ** https://graphacademy.neo4j.com/courses/neo4j-certification/[Neo4j Certification^] - get certified as a Neo4j Professional, free exam with included t-shirt reward following completion!
 * https://graphstuff.fm/[GraphStuff.FM^] - podcast on all things Neo4j and graphs
 

--- a/asciidoc/courses/cypher-post-processing/course.adoc
+++ b/asciidoc/courses/cypher-post-processing/course.adoc
@@ -1,5 +1,5 @@
 = Cypher statement Processing
-:categories: cypher:6, software-development:8, data-analysis:8, advanced:2
+:categories: cypher:6, software-development:8, data-analysis:8, advanced:5
 
 == What you will learn
 

--- a/asciidoc/courses/gds-product-introduction/course.adoc
+++ b/asciidoc/courses/gds-product-introduction/course.adoc
@@ -1,6 +1,6 @@
 = Introduction to Neo4j Graph Data Science
 :usecase: recommendations
-:categories: data-scientist:1, data-analysis:10, advanced:4, analytics:1
+:categories: data-scientist:1, data-analysis:10, advanced:7, analytics:1
 :duration: 30 minutes
 :next: graph-data-science-fundamentals
 :caption: Gain a high-level technical understanding of the Neo4j Graph Data Science (GDS) library

--- a/asciidoc/courses/gds-shortest-paths/course.adoc
+++ b/asciidoc/courses/gds-shortest-paths/course.adoc
@@ -1,6 +1,6 @@
 = Path Finding with GDS
 :usecase: graph-data-science2
-:categories: data-scientist:3, data-analysis:12, advanced:6, analytics:3
+:categories: data-scientist:3, data-analysis:12, advanced:9, analytics:3
 :duration: 1 hour
 :caption: Learn how to find the shortest paths between pairs of nodes in the graph
 :status: active

--- a/asciidoc/courses/genai-fundamentals/course.adoc
+++ b/asciidoc/courses/genai-fundamentals/course.adoc
@@ -1,8 +1,8 @@
 = Neo4j & GenerativeAI Fundamentals
-// :categories: llms:7, intermediate:5, development:8, generative-ai:1
+:categories: llms:7, intermediate:5, development:8, generative-ai:1
 :status: active
 :duration: 2 hours
-:next: llm-knowledge-graph-construction
+:next: llm-vectors-unstructured
 :caption: Learn how Neo4j and GraphRAG can support your Generative AI projects
 :usecase: recommendations
 :key-points: Generative AI Fundamentals, Large Language Models, RAG, GraphRag, Integrating Neo4j with Generative AI

--- a/asciidoc/courses/genai-fundamentals/modules/2-rag/lessons/2-vector-search/lesson.adoc
+++ b/asciidoc/courses/genai-fundamentals/modules/2-rag/lessons/2-vector-search/lesson.adoc
@@ -89,7 +89,7 @@ image::images/vector-distance.svg[A 3 dimensional chart illustrating the distanc
 
 Words with similar meanings or contexts will have vectors that are close together, while unrelated words will be farther apart.
 
-== Vector RAG
+== RAG
 
 This principle is employed in vector based RAG to find contextually relevant results for a user's question.
 

--- a/asciidoc/courses/genai-integration-langchain/course.adoc
+++ b/asciidoc/courses/genai-integration-langchain/course.adoc
@@ -1,9 +1,8 @@
 = Using Neo4j with LangChain
-// TODO - add categories
-:categories: llms:99
-:status: draft
+:categories: llms:10, advanced:2, development:13, generative-ai:4
+:status: active
 :duration: 2 hours
-:next: llm-knowledge-graph-construction
+:next: llm-chatbot-python
 :caption: Learn how to use Neo4j in your GenAI applications with Langchain
 :usecase: recommendations
 :key-points: Integrating Neo4j using LangChain, GraphRAG, Vectors, Text to Cypher

--- a/asciidoc/courses/genai-workshop-graphrag/summary.adoc
+++ b/asciidoc/courses/genai-workshop-graphrag/summary.adoc
@@ -16,5 +16,5 @@ You have:
 Continue your learning with the following resources:
 
 * link:https://graphacademy.neo4j.com[GraphAcademy^] - Free online training for Neo4j
-* link:https://graphacademy.neo4j.com/courses/llm-fundamentals/[Neo4j & LLM Fundamentals^] - Learn how to use Neo4j with Large Language Models
+* link:https://graphacademy.neo4j.com/courses/genai-fundamentals/[Neo4j & GenerativeAI Fundamentals^] - Learn how Neo4j and GraphRAG can support your Generative AI projects
 * link:https://graphacademy.neo4j.com/courses/llm-chatbot-python/[Build a Neo4j-backed Chatbot using Python] - Get hands-on and create a chatbot with Neo4j, Python, and Streamlit

--- a/asciidoc/courses/genai-workshop/summary.adoc
+++ b/asciidoc/courses/genai-workshop/summary.adoc
@@ -16,5 +16,5 @@ You have:
 Continue your learning with the following resources:
 
 * link:https://graphacademy.neo4j.com[GraphAcademy^] - Free online training for Neo4j
-* link:https://graphacademy.neo4j.com/courses/llm-fundamentals/[Neo4j & LLM Fundamentals^] - Learn how to use Neo4j with Large Language Models
+* link:https://graphacademy.neo4j.com/courses/genai-fundamentals/[Neo4j & LLM Fundamentals^] - Learn how Neo4j and GraphRAG can support your Generative AI projects
 * link:https://graphacademy.neo4j.com/courses/llm-chatbot-python/[Build a Neo4j-backed Chatbot using Python] - Get hands-on and create a chatbot with Neo4j, Python, and Streamlit

--- a/asciidoc/courses/graph-data-science-fundamentals/course.adoc
+++ b/asciidoc/courses/graph-data-science-fundamentals/course.adoc
@@ -1,6 +1,6 @@
 = Neo4j Graph Data Science Fundamentals
 :usecase: recommendations
-:categories: data-scientist:2, data-analysis:11, advanced:5, analytics:2
+:categories: data-scientist:2, data-analysis:11, advanced:8, analytics:2
 :duration: 1 hour
 :next: gds-shortest-paths
 :caption: Learn all you need to know about Graph Algorithms and Machine Learning Pipelines

--- a/asciidoc/courses/llm-chatbot-python/course.adoc
+++ b/asciidoc/courses/llm-chatbot-python/course.adoc
@@ -11,7 +11,7 @@
 
 == Course Description
 
-In this hands-on course, you will use the knowledge obtained from the link:/courses/llm-fundamentals[Neo4j & LLM Fundamentals course^] to create a Movie Recommendation Chatbot backed by a Neo4j database.
+In this hands-on course, you will use the knowledge obtained from the link:/courses/genai-fundamentals[Neo4j & GenerativeAI Fundamentals^] and link:/courses/genai-integration-langchain[Using Neo4j with LangChain^] courses to create a Movie Recommendation Chatbot backed by a Neo4j database.
 
 You will take a simple chat interface that repeats the user's input and modify it to answer questions about movies via the Neo4j Recommendations Dataset using _GPT 3.5 Turbo_, complete with conversational history.
 
@@ -26,8 +26,8 @@ At the end of the course, you will have a working chatbot built with link:https:
 
 === Prerequisites
 
-This course relies heavily on the information in the link:/courses/llm-fundamentals[Neo4j & LLM Fundamentals course^].
-We recommend completing this course first if you have not already done so.
+This course relies heavily on the information in the link:/courses/genai-fundamentals[Neo4j & GenerativeAI Fundamentals course^] and link:/courses/genai-integration-langchain[Using Neo4j with LangChain^] courses.
+We recommend completing these courses first if you have not already done so.
 
 We also assume a basic understanding of Python.
 It is not necessary, but you may also benefit from taking the link:/courses/drivers-python/[Using Neo4j with Python^] course to understand how the Neo4j Python Driver works.

--- a/asciidoc/courses/llm-chatbot-python/course.adoc
+++ b/asciidoc/courses/llm-chatbot-python/course.adoc
@@ -1,5 +1,5 @@
 = Build a Neo4j-backed Chatbot using Python
-:categories: llms:10, development:9, generative-ai:4
+:categories: llms:11, development:9, generative-ai:5, advanced:3
 :status: active
 :duration: 2 hours
 :caption: Build a chatbot using Neo4j, Langchain and Streamlit

--- a/asciidoc/courses/llm-chatbot-python/modules/1-project-setup/lessons/1-introduction/lesson.adoc
+++ b/asciidoc/courses/llm-chatbot-python/modules/1-project-setup/lessons/1-introduction/lesson.adoc
@@ -72,7 +72,7 @@ Streamlit provides methods to create link:https://docs.streamlit.io/library/api-
 You will write code to integrate the chatbot with a Large Language Model (LLM).
 At the start of the course, the AI assistant simply _repeats_ the user input.
 
-If you have complete the link:/courses/llm-fundamentals/[Neo4j & LLM Fundamentals course^], you will be familiar with Langchain.
+If you have complete the link:/courses/genai-integration-langchain/[Neo4j & LLM Fundamentals course^], you will be familiar with LangChain.
 link:https://langchain.com[LangChain^] is an open-source framework designed to accelerate the development of LLM applications.
 Langchain provides a flexible base for testing LLMs and out-of-the-box chains for complex tasks.
 

--- a/asciidoc/courses/llm-chatbot-python/modules/2-configuration/lessons/1-llm/lesson.adoc
+++ b/asciidoc/courses/llm-chatbot-python/modules/2-configuration/lessons/1-llm/lesson.adoc
@@ -6,9 +6,7 @@
 :disable-cache: true
 
 
-In the link:/courses/llm-fundamentals/3-intro-to-langchain/[Initializing the LLM lesson of Neo4j & LLM Fundamentals^], you learned how to initialize an LLM class and generate a response from an LLM.
-
-In this lesson, you will need to put this learning into practice by creating an LLM instance to communicate with a GPT model using OpenAI.
+In this lesson, you will need to  creating an LLM instance to communicate with a GPT model using OpenAI.
 
 You will need to:
 

--- a/asciidoc/courses/llm-chatbot-python/modules/2-configuration/lessons/2-neo4j/lesson.adoc
+++ b/asciidoc/courses/llm-chatbot-python/modules/2-configuration/lessons/2-neo4j/lesson.adoc
@@ -5,7 +5,7 @@
 :branch: main
 :disable-cache: true
 
-As you learned in the link:/courses/llm-fundamentals/3-intro-to-langchain/2-initialising-the-llm/[Initializing the LLM lesson of Neo4j & LLM Fundamentals^], Langchain uses the `Neo4jGraph` class to communicate with Neo4j.
+As you learned in the link:/courses/genai-langchain-integration/1-neo4j-integration/4-neo4j-graph/[Neo4jGraph lesson of Neo4j & GenerativeAI Fundamentals^], LangChain uses the `Neo4jGraph` class to communicate with Neo4j.
 
 You will need to create an instance of the `Neo4jGraph` class and connect to the link:https://sandbox.neo4j.com/[Neo4j Sandbox^] instance created for you when you enrolled in the course.
 

--- a/asciidoc/courses/llm-chatbot-python/modules/2-configuration/lessons/3-agent/lesson.adoc
+++ b/asciidoc/courses/llm-chatbot-python/modules/2-configuration/lessons/3-agent/lesson.adoc
@@ -7,7 +7,6 @@
 Your app will interact with the LLM through an _Agent_.
 
 Agents are objects that use an LLM to identify and execute actions in response to a user's input.
-You can learn more in the link:/courses/llm-fundamentals/3-intro-to-langchain/4-agents/[Agents lesson in the Neo4j & LLM Fundamentals course^].
 
 In this lesson, you will create and integrate a new agent into the chatbot.
 

--- a/asciidoc/courses/llm-chatbot-python/modules/3-tools/lessons/1-vector-tool/lesson.adoc
+++ b/asciidoc/courses/llm-chatbot-python/modules/3-tools/lessons/1-vector-tool/lesson.adoc
@@ -3,9 +3,9 @@
 :order: 1
 :branch: main
 
-In the link:/courses/llm-fundamentals/2-vectors-semantic-search/[Vectors & Semantic Search module of the Neo4j & LLM Fundamentals course^], you learned that unstructured content is often converted to vector embeddings to make them easy to compare and contrast, in an approach called Semantic Search.
+In the link:/courses/genai-fundamentals/2-rag/[Retrieval Augmented Generation module of the Neo4j & GenerativeAI Fundamentals^] course, you learned that unstructured content is often converted to vector embeddings to make them easy to compare and contrast, in an approach called Semantic Search.
 
-In the link:/courses/llm-fundamentals/3-intro-to-langchain/6-retrievers/[Retrievers lesson^], you also learned how to create an instance of the `Neo4jVector` Store.
+In the link:/courses/genai-integration-langchain/2-vectors/2-vector-retriever/[Vector Retriever lesson^], you also learned how to create an instance of the `Neo4jVector` Store.
 
 In this challenge, you will use that knowledge to create and register a tool that will use a Vector Search Index created on embeddings of the  `.plot` property of each movie to find similar movies.
 
@@ -18,7 +18,7 @@ You will need to:
 
 == Creating a Neo4j Vector Store
 
-In Langchain, a Vector Store handles the interaction between the application and a Vector database.
+In LangChain, a Vector Store handles the interaction between the application and a Vector database.
 
 To interact with link:https://neo4j.com/docs/cypher-manual/current/indexes-for-vector-search/[Neo4j Vector Search Indexes^], you must create an instance of the `Neo4jVector` store.
 

--- a/asciidoc/courses/llm-chatbot-python/modules/3-tools/lessons/2-cypher-tool/lesson.adoc
+++ b/asciidoc/courses/llm-chatbot-python/modules/3-tools/lessons/2-cypher-tool/lesson.adoc
@@ -4,7 +4,7 @@
 :branch: main
 
 In the previous challenge, you created a tool that used the `Neo4jVector` Store and a retriever chain to identify movies with similar plots to the user's input.
-This approach may be relatively easy to set up, but as you learned in link:/courses/llm-fundamentals/2=vectors-semantic-search/[Vectors & Semantic Search module of the Neo4j & LLM Fundamentals] course, this approach can have its drawbacks.
+This approach may be relatively easy to set up, but as you learned in link:/courses/genai-fundamentals/2-rag/[Retrieval Augmented Generation module of the Neo4j & GenerativeAI Fundamentals^] course, this approach can have its drawbacks.
 
 Semantic Search using Vector Similarity relies on relative proximity in vector space, which may not provide a precise match.
 

--- a/asciidoc/courses/llm-chatbot-typescript/course.adoc
+++ b/asciidoc/courses/llm-chatbot-typescript/course.adoc
@@ -15,7 +15,7 @@
 
 == Course Description
 
-In this hands-on course, you will use the knowledge obtained from the link:/courses/llm-fundamentals[Neo4j & LLM Fundamentals course^] to create a Movie Recommendation Chatbot backed by a Neo4j database.
+In this hands-on course, you will use the knowledge obtained from the link:/courses/genai-fundamentals[Neo4j & GenerativeAI Fundamentals course^] to create a Movie Recommendation Chatbot backed by a Neo4j database.
 
 You will take a simple chat interface that repeats the user's input and modify it to answer questions about movies via the Neo4j Recommendations Dataset using GPT-4, complete with conversation history.
 
@@ -30,7 +30,7 @@ At the end of the course, you will have a working chatbot built in React using l
 
 === Prerequisites
 
-This course relies heavily on the information in the link:/courses/llm-fundamentals[Neo4j & LLM Fundamentals course^].
+This course relies heavily on the information in the link:/courses/genai-fundamentals[Neo4j & GenerativeAI Fundamentals course^].
 We recommend completing this course first if you have not already done so.
 
 We also assume a basic understanding of TypeScript and Next.js.

--- a/asciidoc/courses/llm-chatbot-typescript/course.adoc
+++ b/asciidoc/courses/llm-chatbot-typescript/course.adoc
@@ -1,5 +1,5 @@
 = Build a Neo4j-backed Chatbot with TypeScript
-:categories: llms:11, development:10, generative-ai:5
+:categories: llms:12, development:10, generative-ai:6, advanced:4
 :status: active
 :duration: 6 hours
 :caption: Build a chatbot using Neo4j, Langchain and Next.js
@@ -14,7 +14,7 @@
 // :reward-product-id: @65f874e831d488,@65f875094279d1
 
 == Course Description
-at
+
 In this hands-on course, you will use the knowledge obtained from the link:/courses/llm-fundamentals[Neo4j & LLM Fundamentals course^] to create a Movie Recommendation Chatbot backed by a Neo4j database.
 
 You will take a simple chat interface that repeats the user's input and modify it to answer questions about movies via the Neo4j Recommendations Dataset using GPT-4, complete with conversation history.

--- a/asciidoc/courses/llm-chatbot-typescript/modules/1-project-setup/lessons/1-introduction/lesson.adoc
+++ b/asciidoc/courses/llm-chatbot-typescript/modules/1-project-setup/lessons/1-introduction/lesson.adoc
@@ -34,17 +34,14 @@ include::{repository-raw}/main/src/modules/agent/index.ts[tag=call]
 // TODO: Add screenshot
 
 
-== LLM Integration with Langchain
+== LLM Integration with LangChain
 
 As you progress through the course, you will replace the `call()` function above with an agent capable of deciphering which tool to use and generating a response with the help of an LLM.
 
-If you have link:/courses/llm-fundamentals/[completed the Neo4j & LLM Fundamentals course^], you will be familiar with Langchain and the concept of agents.
 link:https://langchain.com[LangChain^] is an open-source framework designed to accelerate the development of LLM applications.
-We have chosen Langchain because it provides a flexible base for testing LLMs and out-of-the-box chains for performing complex tasks.
+We have chosen LangChain because it provides a flexible base for testing LLMs and out-of-the-box chains for performing complex tasks.
 
 Although we have chosen a specific framework, the course focuses on the LLM integration details, which should be transferrable to your framework of choice.
-
-Although the link:/courses/llm-fundamentals/[Neo4j & LLM Fundamentals course^] covers the Python library, and the code samples may differ, the overall concepts used in the TypeScript library are identical.
 
 
 == LLMs from OpenAI

--- a/asciidoc/courses/llm-chatbot-typescript/modules/2-chains/lessons/1-introduction-to-lcel/lesson.adoc
+++ b/asciidoc/courses/llm-chatbot-typescript/modules/2-chains/lessons/1-introduction-to-lcel/lesson.adoc
@@ -2,7 +2,6 @@
 :type: lesson
 :order: 1
 
-In the link:/courses/llm-fundamentals[Neo4j & LLM Fundamentals course^], we used chains provided by LangChain to communicate with the LLM.
 This lesson will teach you how to create custom chains using **LangChain Expression Language**.
 
 == What is LCEL?
@@ -23,7 +22,6 @@ You can link:https://js.langchain.com/docs/expression_language/[read more about 
 
 == An example chain
 
-In the link:https://graphacademy.neo4j.com/courses/llm-fundamentals/3-intro-to-langchain/2.5-chains/[Chains lesson in Neo4j & LLM Fundamentals^], you learned about the `LLMChain`.
 The link:https://api.python.langchain.com/en/latest/_modules/langchain/chains/llm.html#LLMChain[`LLMChain`^] is an example of a simple chain that, when invoked, takes a user input, replaces the value inside the prompt and passes the prompt to an LLM and specifies the result.
 
 // [source]

--- a/asciidoc/courses/llm-chatbot-typescript/modules/4-vector-retrieval/lessons/1-vector-stores/lesson.adoc
+++ b/asciidoc/courses/llm-chatbot-typescript/modules/4-vector-retrieval/lessons/1-vector-stores/lesson.adoc
@@ -10,7 +10,7 @@
 
 In the link:../../2-chains/2-answer-generation/[Answer Generation Chain lesson^], you built a chain that answers a question based on the context provided in the prompt.
 
-As we covered in the link:/courses/llm-fundamentals/2-vectors-semantic-search[Retrievers lesson of Neo4j & LLM Fundamentals^], semantic search in LangChain is performed using an object called a **Retriever**.
+As we covered in the link:/courses/genai-fundamentals/4-integrating-neo4j/2-vector-retriever[Vector Retriever lesson of Neo4j & GenerativeAI Fundamentals^], semantic search in LangChain is performed using an object called a **Retriever**.
 
 A Retriever is an abstraction that uses a **Vector Store** to identify similar documents based on an input by converting the input into a vector embedding and performing a similarity search against the vectors stored in an index.
 
@@ -34,7 +34,7 @@ The statement creates a new index called `moviePlots`, indexing the vectors in t
 The vectors stored in the `embedding` property have been created using the `text-embedding-ada-002` model and therefore have `1536` dimensions.
 The index will use `cosine` similarity to identify similar documents.
 
-To learn more about how Vector Retrievers work, link:/courses/llm-fundamentals/3-intro-to-langchain/6-retrievers/[see the Retrievers lesson in Neo4j & LLM Fundamentals^].
+To learn more about how Vector Retrievers work, link:/courses/genai-fundamentals/4-integrating-neo4j/2-vector-retriever[see the Vector Retriever lesson of Neo4j & GenerativeAI Fundamentals^].
 
 Next, run the following statement to load a CSV file containing embeddings of movie plots.
 

--- a/asciidoc/courses/llm-fundamentals/course.adoc
+++ b/asciidoc/courses/llm-fundamentals/course.adoc
@@ -1,6 +1,7 @@
 = Neo4j & LLM Fundamentals
-:categories: llms:7, intermediate:5, development:8, generative-ai:1
+// :categories: llms:7, intermediate:5, development:8, generative-ai:1
 :status: active
+:redirect: /courses/genai-fundamentals
 :duration: 4 hours
 :next: llm-chatbot-python
 :caption: Learn how to use Neo4j with Large Language Models

--- a/asciidoc/courses/llm-knowledge-graph-construction/course.adoc
+++ b/asciidoc/courses/llm-knowledge-graph-construction/course.adoc
@@ -1,5 +1,5 @@
 = Building Knowledge Graphs with LLMs
-:categories: llms:9, advanced:3, processing:4, generative-ai:3
+:categories: llms:9, advanced:6, processing:4, generative-ai:3
 :status: active
 :duration: 2 hours
 :caption: Learn how to use Generative AI, LLMs and Python to convert unstructured data into graphs.

--- a/asciidoc/courses/llm-vectors-unstructured/course.adoc
+++ b/asciidoc/courses/llm-vectors-unstructured/course.adoc
@@ -1,7 +1,7 @@
 = Introduction to Vector Indexes and Unstructured Data
 :categories: llms:8, intermediate:6, processing:3, generative-ai:2
 :status: active
-:next: llm-python-chatbot
+:next: llm-knowledge-graph-constructions
 :duration: 2 hours
 :caption: Understand and search unstructured data using vector indexes
 :usecase: blank-sandbox


### PR DESCRIPTION
Changes required to make genai-fundamentals and genai-integration-langchain live, and redirect `llm-fundamentals`.

In summary:
- making courses `active`
- setting categories across courses
- changing links from courses to `llm-fundamentals` - there is more work to do post go live on `llm-vectors-unstructured`, `llm-knowledge-graphs-construction` but this can be done later.