### PR TITLE
Add a new conversation lesson type to genai-mcp-neo4j-tools

### DIFF
--- a/asciidoc/courses/genai-mcp-neo4j-tools/modules/1-what-is-mcp/lessons/5-clarify/lesson.adoc
+++ b/asciidoc/courses/genai-mcp-neo4j-tools/modules/1-what-is-mcp/lessons/5-clarify/lesson.adoc
@@ -1,0 +1,8 @@
+= Ask E.L.A.I.N.E 
+:type: conversation 
+:order: 5
+
+Are there any questions you have about the content of this module?  Or anything you'd like to discuss?
+
+Ask me a question below and I will do by best to answer it.
+

--- a/asciidoc/courses/genai-mcp-neo4j-tools/modules/1-what-is-mcp/llms.txt
+++ b/asciidoc/courses/genai-mcp-neo4j-tools/modules/1-what-is-mcp/llms.txt
@@ -1,0 +1,95 @@
+# Module: What is MCP?
+
+## Overview
+This module introduces the core concepts of the Model Context Protocol (MCP) and how it enables agents to work together in a standardized way. Students learn about agentic systems, MCP architecture, and practical implementation through installing MCP servers.
+
+## Module Structure
+- **Title**: Agentic Systems and MCP
+- **Order**: 1
+- **Type**: Foundational module
+- **Duration**: 5 lessons
+
+## Learning Objectives
+By the end of this module, students will:
+1. Understand what agents are and how they work using the ReAct framework
+2. Explain the Model Context Protocol (MCP) and its role in agent communication
+3. Identify the key components of MCP architecture (Servers, Clients, Hosts, Tools)
+4. Configure and install MCP servers with environment variables
+5. Verify MCP server installation and tool availability
+
+## Key Concepts Covered
+
+### Agents and ReAct Framework
+- **Agents**: Systems that act independently using tool calling to achieve specific goals
+- **ReAct Framework**: Continuous loop of planning, reasoning, and acting
+- **Planning**: Analyzing tasks, breaking into sub-tasks, extracting parameters
+- **Reasoning**: Selecting appropriate tools based on available descriptions
+- **Acting**: Executing tools in sequence or parallel to gather information
+
+### Model Context Protocol (MCP)
+- **Definition**: Open protocol developed by Anthropic for standardized AI agent communication
+- **Purpose**: Enables agents to access tools and resources from third parties
+- **Architecture**: Client-server model similar to microservices
+- **Transport Methods**: stdio (local) and HTTP (remote)
+
+### MCP Architecture Components
+
+#### Servers
+- Provide capabilities through tools, resources, and prompt templates
+- Each tool has: unique identifier, description, parameter list
+- **Resources**: Read-only data with unique URIs
+- **Prompt Templates**: Pre-written prompts following best practices
+
+#### Clients
+- Manage one-to-one connections to servers
+- Maintain stateful connections throughout lifecycle
+- Request lists of available tools, resources, and templates
+
+#### Hosts
+- Applications managing one or more clients (Claude Desktop, VS Code, Cursor)
+- Maintain session state and context
+- Determine which tools to use and provide parameters
+
+#### Tools
+- Unique identifiers and descriptions
+- Defined parameters and expected outputs
+- Can return text or Base-64 encoded images
+
+### Configuration and Installation
+- **Configuration Files**: JSON documents specifying server details
+- **Environment Variables**: Settings passed to servers (credentials, URIs)
+- **Command Structure**: Separate command and arguments for proper execution
+- **Verification**: Using host commands to confirm server installation
+
+## Practical Implementation
+Students practice with:
+- Neo4j Cypher MCP Server installation
+- Environment variable configuration
+- Tool verification and testing
+- Database connection setup
+
+## Assessment Methods
+- **Pop Quiz**: Multiple choice questions on MCP concepts
+- **Practical Challenge**: Installing and configuring MCP server
+- **Verification Tasks**: Confirming tool availability and functionality
+
+## Prerequisites
+- Basic understanding of databases (helpful but not required)
+- Familiarity with command-line interfaces
+- Access to VS Code or similar development environment
+
+## Tools and Technologies
+- **MCP Servers**: Neo4j Cypher MCP Server
+- **Package Managers**: uv/uvx for Python packages
+- **Development Environment**: VS Code with Copilot
+- **Database**: Neo4j (sandbox instance provided)
+
+## Key Takeaways
+1. MCP standardizes how agents consume external tools
+2. Architecture separates concerns between servers, clients, and hosts
+3. Configuration requires both server details and environment variables
+4. Practical implementation involves specific installation and verification steps
+5. MCP enables agents to work with real data and systems, not just theoretical concepts
+
+## Next Steps
+After completing this module, students advance to exploring the full capabilities of Neo4j Cypher MCP server tools and their practical applications in agent-based workflows. 

--- a/src/services/build-html.ts
+++ b/src/services/build-html.ts
@@ -8,21 +8,25 @@ export default async function buildHtml(): Promise<void> {
 
   console.log(`↔️  Building HTML`)
 
-  // Build HTML
-  for (const course of courses) {
-    void buildCourseHtml(course)
-  }
+  // Build all HTML in parallel for maximum speed
+  const [courseResults, moduleResults, lessonResults] = await Promise.all([
+    // Build all courses in parallel
+    Promise.all(courses.map(course => buildCourseHtml(course))),
+    
+    // Build all modules in parallel
+    Promise.all(modules.map(module => {
+      console.log(`   -- ${module.course.slug}/${module.slug}`)
+      return buildModuleHtml(module)
+    })),
+    
+    // Build all lessons in parallel
+    Promise.all(lessons.map(lesson => {
+      console.log(`   -- ${lesson.course.slug}/${lesson.module.slug}/${lesson.slug}`)
+      return buildLessonHtml(lesson)
+    }))
+  ])
+
   console.log(`   -- ${courses.length} courses`)
-
-  for (const module of modules) {
-    console.log(`   -- ${module.slug}`)
-    void buildModuleHtml(module)
-  }
   console.log(`   -- ${modules.length} modules`)
-
-  for (const lesson of lessons) {
-    console.log(`   -- ${lesson.slug}`)
-    void buildLessonHtml(lesson)
-  }
   console.log(`   -- ${lessons.length} lessons`)
 }


### PR DESCRIPTION
Adding `:type: conversation` opens the chatbot full screen with the page content written in the file as the first message/cold start.  Asking the first question should trigger a tool that fetches the module content (llms.txt if it exists) before answering the user's question.

Requires additional testing.

Depends on https://github.com/neo4j-graphacademy/website/pull/145