### PR TITLE
workshop-genai - Split retrievers into separate notebooks

### DIFF
--- a/asciidoc/courses/workshop-genai/modules/2-retrievers/lessons/3-hands-on-retrievers/lesson.adoc
+++ b/asciidoc/courses/workshop-genai/modules/2-retrievers/lessons/3-hands-on-retrievers/lesson.adoc
@@ -4,27 +4,32 @@
 
 [.slide.discrete]
 == Introduction
-In this lesson, you will work hands-on with all three retriever types using a Jupyter notebook to see how they work in practice.
+In this lesson, you will work hands-on with all three retriever types to see how they work in practice.
+
+There are three Jupyter notebooks to explore:
+
+. `01_01_vector_retriever.ipynb` - Vector Retriever
+. `01_02_vector_cypher_retriever.ipynb` - Vector + Cypher Retriever
+. `01_03_text2cypher_retriever.ipynb` - Text2Cypher Retriever
 
 [.slide]
-== Hands-On: Retriever Notebook
+== Hands-On: Retriever Notebooks
 
-Open the notebook: `01_Retrievers_notebook.ipynb`
+Open the first notebook: `01_01_vector_retriever.ipynb`
 
-This notebook demonstrates:
+Each notebook demonstrates:
 
-1. **Setting up retrievers** with the knowledge graph we built
-2. **Vector retrieval** for semantic search
-3. **Hybrid retrieval** combining vectors and graph traversal  
-4. **Text2Cypher** for structured queries
-5. **Comparing results** from different retrieval methods
+1. **Setting up the retriever** with the knowledge graph we built
+2. **Customizing the retriever** for your requirements
+3. **Using the retriever** as part of a GraphRAG pipeline
+4. **Comparing results** from different retrieval methods
 
 [.transcript-only]
 ====
 
 **What You'll Build:**
 
-As you work through the notebook, take time to review the code snippets and understand how each retriever is initialized and used.
+As you work through the notebooks, take time to review the code snippets and understand how each retriever is initialized and used.
 
 Note how each retriever has its place in a complete GraphRAG system!
 


### PR DESCRIPTION
## General Update PR

## Description

Split the workshop-genai retrievers lesson into 3 separate notebooks and refactor some of the instruction to be more direct.

## Dependencies

Dependent on changes in the `workshop-genai` repo -  https://github.com/neo4j-graphacademy/workshop-genai/pull/3
