### PR TITLE
fix(gds-community-detection): fix KMeans lessons using wrong property

### DIFF
--- a/asciidoc/courses/gds-community-detection/modules/3-kmeans/lessons/2-kmeans/lesson.adoc
+++ b/asciidoc/courses/gds-community-detection/modules/3-kmeans/lessons/2-kmeans/lesson.adoc
@@ -117,6 +117,37 @@ include::questions/1-deterministic.adoc[leveloffset=+1]
 
 include::questions/2-kmeans.adoc[leveloffset=+1]
 
+
+== Troubleshooting
+
+If you receive an error stating that the graph does not exist, you may need to recreate the `survey` graph projection from the link:/courses/gds-community-detection/3-kmeans/1-scaling/[Feature normalization^] lesson.
+
+.Recreate the graph projection
+[%collapsible]
+====
+[source,cypher]
+----
+CALL gds.graph.drop('survey', false);
+
+CALL gds.graph.project(
+  'survey',
+  'Person',
+  '*',
+  {nodeProperties:['vector']}
+);
+
+CALL gds.scaleProperties.mutate(
+  'survey',
+  {
+    nodeProperties: ['vector'],
+    scaler: 'MinMax',
+    mutateProperty: 'scaledVector'
+  }
+);
+----
+====
+
+
 [.summary]
 == Summary
 

--- a/asciidoc/courses/gds-community-detection/modules/3-kmeans/lessons/3-optimization/lesson.adoc
+++ b/asciidoc/courses/gds-community-detection/modules/3-kmeans/lessons/3-optimization/lesson.adoc
@@ -27,7 +27,7 @@ You will use the *stats* mode of the algorithm as you are only interested in the
 ----
 UNWIND range(5,20) AS k
 CALL gds.beta.kmeans.stats('survey',
-  {k:k, nodeProperty:'vector', computeSilhouette: True})
+  {k:k, nodeProperty:'scaledVector', computeSilhouette: true})
 YIELD averageDistanceToCentroid, averageSilhouette
 RETURN k, averageDistanceToCentroid, averageSilhouette
 ORDER BY averageSilhouette DESC LIMIT 3;
@@ -48,7 +48,7 @@ In this example, you will use the `numberOfRestarts` value 5.
 [source,cypher]
 ----
 CALL gds.beta.kmeans.write('survey',
-  {k:5, nodeProperty:'vector',
+  {k:5, nodeProperty:'scaledVector',
    numberOfRestarts: 5,
    writeProperty:'kmeans5'})
 ----
@@ -60,6 +60,37 @@ CALL gds.beta.kmeans.write('survey',
 
 include::questions/1-metric.adoc[leveloffset=+1]
 include::questions/2-restarts.adoc[leveloffset=+1]
+
+
+== Troubleshooting
+
+If you receive an error stating that the graph does not exist, you may need to recreate the `survey` graph projection from the link:/courses/gds-community-detection/3-kmeans/1-scaling/[Feature normalization^] lesson.
+
+.Recreate the graph projection
+[%collapsible]
+====
+[source,cypher]
+----
+CALL gds.graph.drop('survey', false);
+
+CALL gds.graph.project(
+  'survey',
+  'Person',
+  '*',
+  {nodeProperties:['vector']}
+);
+
+CALL gds.scaleProperties.mutate(
+  'survey',
+  {
+    nodeProperties: ['vector'],
+    scaler: 'MinMax',
+    mutateProperty: 'scaledVector'
+  }
+);
+----
+====
+
 
 [.summary]
 == Summary


### PR DESCRIPTION
## Summary

Fixes issues in the KMeans module of the GDS Community Detection course based on negative user feedback (84.6% negative rating on lesson 3).

## Changes

### Bug fix: Incorrect property name
- **Lesson 3** was using `nodeProperty:'vector'` instead of `nodeProperty:'scaledVector'`
- This was inconsistent with lesson 2 and meant users were running KMeans on unscaled data
- Fixed both `gds.beta.kmeans.stats` and `gds.beta.kmeans.write` calls

### Added troubleshooting sections
- Added collapsible troubleshooting section to **lessons 2 and 3** (at bottom, not intrusive)
- Includes recovery Cypher to recreate the `survey` graph projection if it doesn't exist
- Addresses the most common user complaint: "Graph with name `survey` does not exist"

### Minor fix
- Changed `computeSilhouette: True` → `computeSilhouette: true` (proper Cypher boolean syntax)

## User feedback addressed

| Feedback | Fix |
|----------|-----|
| "Graph with name `survey` does not exist" | Troubleshooting section with recovery code |
| "All the cypher commands don't work" | Fixed property name inconsistency |
| "Correct answers not validated" | Likely related to graph not existing |

## Files changed
- `modules/3-kmeans/lessons/2-kmeans/lesson.adoc`
- `modules/3-kmeans/lessons/3-optimization/lesson.adoc`

## Feedback addressed

Resolves negative feedback for lesson `3-optimization`:
- `6591923b-...` - "Graph with name `survey` does not exist" → Added troubleshooting section
- `79a4cef2-...` - "All the cypher commands don't work" → Fixed `vector` → `scaledVector`
- `ff933534-...`, `36a3412f-...`, `c9f379f3-...` - Quiz validation issues → Related to graph/property fixes
- `f8187088-...`, `63b002ed-...`, `b69a5230-...`, `3d964f1e-...` - "Unresolved directive" → Previously fixed (include filename was corrected)
- `57f7c169-...`, `a302baa4-...` - "It's broken" → General fixes above