### PR TITLE
fix(app-typescript): add expected output and troubleshooting to writi…

### DIFF
--- a/asciidoc/courses/app-typescript/modules/1-driver/lessons/5-c-writing-data/lesson.adoc
+++ b/asciidoc/courses/app-typescript/modules/1-driver/lessons/5-c-writing-data/lesson.adoc
@@ -49,7 +49,20 @@ Run the file using `ts-node` to view the result:
 ts-node {lab-file}
 ----
 
-You can check the result in the Neo4j Browser by running the following query:
+If successful, you should see output similar to the following (with your name instead of "Your Name"):
+
+.Expected Output
+[source,json,role=nocopy]
+----
+{
+  identity: Integer { low: 12345, high: 0 },
+  labels: [ 'Person' ],
+  properties: { name: 'Your Name' },
+  elementId: '4:abc123:12345'
+}
+----
+
+You can also verify the result in the Neo4j Browser by running the following query:
 
 [source, cypher]
 ----
@@ -57,7 +70,56 @@ MATCH (m:Movie {title: "Matrix, The"})<-[a:ACTED_IN]-(p:Person)
 RETURN m, a, p
 ----
 
+You should see your `Person` node connected to _The Matrix_ movie.
+
+
 include::questions/verify.adoc[leveloffset=+1]
+
+
+== Troubleshooting
+
+.ts-node: command not found
+[%collapsible]
+====
+If you receive a `ts-node: command not found` error, you can either:
+
+1. Install `ts-node` globally:
++
+[source,sh]
+----
+npm install -g ts-node
+----
+
+2. Or run via npx:
++
+[source,sh,subs=attributes+]
+----
+npx ts-node {lab-file}
+----
+====
+
+.Cannot use import statement outside a module
+[%collapsible]
+====
+This error occurs when Node.js tries to run TypeScript/ES modules as CommonJS.
+Ensure your `tsconfig.json` has the correct module settings, or run with:
+
+[source,sh,subs=attributes+]
+----
+npx ts-node --esm {lab-file}
+----
+====
+
+.Verification fails but code works
+[%collapsible]
+====
+If your code runs successfully and creates the node (you can see it in Neo4j Browser) but the verification fails:
+
+1. Ensure you are using the sandbox provided by GraphAcademy (not a local database)
+2. Check that the Person node was created with an `ACTED_IN` relationship to the movie titled "Matrix, The"
+3. Try refreshing the page and clicking Verify again
+====
+
 
 [.summary]
 == Lesson Summary
@@ -65,3 +127,5 @@ include::questions/verify.adoc[leveloffset=+1]
 In this challenge, you used your knowledge to create a driver instance and run a Cypher statement.
 
 Next, we will look at the Neo4j Type System and some of the considerations that you need to make when working with values coming from Neo4j in your TypeScript application.
+
+// @last-fix 2025-12-02


### PR DESCRIPTION
## Summary

Improves the "Writing Data to Neo4j" lesson in the TypeScript course based on user feedback (84% negative rating).

## Changes

### Added Expected Output section
Users now see what successful output looks like before running verification, so they can confirm their code works independently of the verify button.

### Added Troubleshooting section (collapsible)
Three common issues addressed:

| Issue | Solution |
|-------|----------|
| `ts-node: command not found` | Install globally or use `npx ts-node` |
| `Cannot use import statement outside a module` | Use `npx ts-node --esm` flag |
| Verification fails but code works | Check sandbox usage, movie title, try refresh |

## Feedback addressed

| ID | Issue |
|----|-------|
| `c36f4359-ae13-4954-a7e6-ac04b7bab6ea` | ts-node: command not found |
| `78115078-1dc8-4091-837b-dd37f2efa80b` | Cannot use import statement outside a module |
| `75c5b45e-d95e-4da6-9df8-7cf1d36ff581` | "no way to know if I'm on right track" |
| `9cea838f-85ab-4a69-a656-3a0b9a925d8c` | "Inadequate information" |
| `f8bec257-7334-4b34-9f12-6c09d2f68824` | Verification fails but code works |
| `d89143d6-39b3-4881-bfa8-ac64d9a711de` | Check doesn't work but result correct |

## Files changed

- `asciidoc/courses/app-typescript/modules/1-driver/lessons/5-c-writing-data/lesson.adoc`

## Notes

Some feedback issues (JSON errors, sandbox provisioning failures) are infrastructure-related and cannot be addressed through content changes alone.