### PR TITLE
Uplift streamlit version and add database

### DIFF
--- a/asciidoc/courses/llm-chatbot-python/modules/2-configuration/lessons/2-neo4j/lesson.adoc
+++ b/asciidoc/courses/llm-chatbot-python/modules/2-configuration/lessons/2-neo4j/lesson.adoc
@@ -24,6 +24,7 @@ Scheme:: [copy]#bolt#
 Connection URL:: [copy]#{instance-ip}#
 Username:: [copy]#{instance-username}#
 Password:: [copy]#{instance-password}#
+Database:: [copy]#{instance-database}#
 
 
 Set these as secrets in the Streamlit app by opening the `.streamlit/secrets.toml` and adding the following values.


### PR DESCRIPTION
## General Update PR

## Description

Streamlit have released a new version including a warning prompting learners to upgrade their streamlit version. When they do, the project no longer works because of a changed import.

Also made a small change the add the database information to the setup lesson

Dependent on https://github.com/neo4j-graphacademy/llm-chatbot-python/pull/27

## Related Issues

- Closes [llm-chatbot-python #[26]](https://github.com/neo4j-graphacademy/llm-chatbot-python/issues/26)

## Testing

- [x] Tested locally
- [x] All existing tests pass
