### PR TITLE
GRAC-192: Add questions to database

### DIFF
--- a/src/services/load/graph-ids.ts
+++ b/src/services/load/graph-ids.ts
@@ -1,0 +1,27 @@
+/**
+ * Match Neo4j `apoc.text.base64Encode` for UTF-8 strings (used in MERGE keys).
+ */
+export function apocBase64Encode(s: string): string {
+  return Buffer.from(s, "utf8").toString("base64");
+}
+
+/** Composite (:Lesson).id — same as `apoc.text.base64Encode(lesson.link)` in tx.cypher */
+export function lessonNodeId(lessonLink: string): string {
+  return apocBase64Encode(lessonLink);
+}
+
+/** Composite (:Question).id — same as `apoc.text.base64Encode(l.id + '--' + questionSlug)` */
+export function questionNodeId(lessonLink: string, questionSlug: string): string {
+  return apocBase64Encode(`${lessonNodeId(lessonLink)}--${questionSlug}`);
+}
+
+/** Composite (:Answer).id — same as `apoc.text.base64Encode(l.id + '--' + questionSlug + '--' + index)` */
+export function answerNodeId(
+  lessonLink: string,
+  questionSlug: string,
+  index: number,
+): string {
+  return apocBase64Encode(
+    `${lessonNodeId(lessonLink)}--${questionSlug}--${index}`,
+  );
+}

--- a/src/services/load/index.ts
+++ b/src/services/load/index.ts
@@ -1,7 +1,10 @@
 import loadCourses, { CourseToImport } from "./load-courses";
 import loadLessons, { LessonToImport } from "./load-lessons";
 import loadModules, { ModuleToImport } from "./load-modules";
-import loadQuestions, { QuestionToImport } from "./load-questions";
+import loadQuestions, {
+  AnswerToImport,
+  QuestionToImport,
+} from "./load-questions";
 
 type LoadOutput = {
   courses: CourseToImport[];
@@ -9,6 +12,8 @@ type LoadOutput = {
   lessons: LessonToImport[];
   questions: QuestionToImport[];
 }
+
+export type { AnswerToImport, QuestionToImport };
 
 export default async function load(): Promise<LoadOutput> {
   const courses = await loadCourses()

--- a/src/services/load/load-questions.ts
+++ b/src/services/load/load-questions.ts
@@ -1,77 +1,252 @@
 import { join, parse } from "path";
+import { readFile } from "fs/promises";
 import { LessonToImport } from "./load-lessons";
-import { convert, doc, loadFile } from "../../modules/asciidoc";
+import { doc, loadFile } from "../../modules/asciidoc";
 import { COURSE_DIRECTORY } from "../../constants";
 import { existsSync } from "fs";
 import { readdir } from "fs/promises";
+import { answerNodeId } from "./graph-ids";
+
+export type AnswerToImport = {
+  id: string;
+  text: string;
+  correct: boolean;
+  /** Display order within the question (0-based, checklist order). */
+  order: number;
+};
 
 export type QuestionToImport = {
   id: string;
   filename: string;
+  basename: string;
+  title: string;
   text: string;
-}
+  lessonLink: string;
+  type: string;
+  hint: string | null;
+  solution: string | null;
+  order: number;
+  answers: AnswerToImport[];
+};
 
 const generateQuestionId = (title: string): string => {
-  const adoc = `== ${title}`
-  const html = doc.load(adoc).convert()
+  const adoc = `== ${title}`;
+  const html = doc.load(adoc).convert();
   const matches = html.match(/<h2 id="([^"]+)">/);
 
   if (matches) {
     return matches[1];
   }
 
-  return '_' + title.replace(/(<([^>]+)>)/gi, "")
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/_+$/g, '')
+  return (
+    "_" +
+    title
+      .replace(/(<([^>]+)>)/gi, "")
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "_")
+      .replace(/_+$/g, "")
+  );
+};
+
+function stripBlockComments(raw: string): string {
+  return raw.replace(/\/\/\/\/[\s\S]*?\/\/\/\//g, "");
 }
 
-const loadQuestion = (lesson: LessonToImport, filename: string): QuestionToImport => {
-  const parsed = parse(filename)
-  const file = loadFile(
-    join(
-      COURSE_DIRECTORY,
-      lesson.course.slug,
-      'modules',
-      lesson.module.slug,
-      'lessons',
-      lesson.slug,
-      'questions',
-      filename
-    ), { parse_header_only: true }
-  )
-  const id = file.getAttribute('id', generateQuestionId(file.getDocumentTitle({ sanitize: true }) as string))
+function extractTipBlock(raw: string, role: "hint" | "solution"): string | null {
+  const re = new RegExp(
+    `\\[TIP,role=${role}\\]\\s*\\n(?:\\.[^\\n]*\\n)?====\\s*\\n([\\s\\S]*?)\\n====`,
+    "m",
+  );
+  const m = raw.match(re);
+  return m ? m[1].trim() : null;
+}
+
+function extractChecklistOptions(raw: string): { text: string; correct: boolean }[] {
+  const options: { text: string; correct: boolean }[] = [];
+  const lines = raw.split(/\r?\n/);
+  let inChecklist = false;
+  for (const line of lines) {
+    const m = line.match(/^\s*[\*\-]\s*\[([ xX])\]\s*(.+)$/);
+    if (m) {
+      inChecklist = true;
+      options.push({
+        correct: m[1].toLowerCase() === "x",
+        text: m[2].trim(),
+      });
+    } else if (inChecklist) {
+      // Blank lines between options are common; only stop at non-empty non-checklist lines.
+      if (line.trim() === "") {
+        continue;
+      }
+      break;
+    }
+  }
+  return options;
+}
+
+/** First section title line (`= ...`) after optional `[.question]` / `[.verify]`. */
+function extractTitleFromRaw(raw: string): string {
+  const lines = stripBlockComments(raw).split(/\r?\n/);
+  let i = 0;
+  if (lines[i]?.match(/^\[\.(question|verify)\]/)) {
+    i++;
+  }
+  while (i < lines.length && lines[i].trim() === "") {
+    i++;
+  }
+  const m = lines[i]?.match(/^=\s+(.+)$/);
+  return m ? m[1].trim() : "";
+}
+
+function extractStem(raw: string): string {
+  const withoutComments = stripBlockComments(raw);
+  const lines = withoutComments.split(/\r?\n/);
+  let i = 0;
+  if (lines[i]?.match(/^\[\.(question|verify)\]/)) {
+    i++;
+  }
+  while (i < lines.length && lines[i].trim() === "") {
+    i++;
+  }
+  if (!lines[i]?.match(/^=\s+/)) {
+    return "";
+  }
+  i++;
+  while (i < lines.length && lines[i].trim() === "") {
+    i++;
+  }
+  const stemLines: string[] = [];
+  for (; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (trimmed.match(/^[\*\-]\s*\[[ xX]\]/)) {
+      break;
+    }
+    if (trimmed.startsWith("verify::")) {
+      break;
+    }
+    if (trimmed.startsWith("[TIP")) {
+      break;
+    }
+    if (trimmed.startsWith("image::")) {
+      break;
+    }
+    stemLines.push(lines[i]);
+  }
+  return stemLines.join("\n").trim();
+}
+
+function detectBlockRole(raw: string): "verify" | "question" | null {
+  const m = stripBlockComments(raw).match(/^\[\.(question|verify)\]/m);
+  if (m?.[1] === "verify") {
+    return "verify";
+  }
+  if (m?.[1] === "question") {
+    return "question";
+  }
+  return null;
+}
+
+const loadQuestion = async (
+  lesson: LessonToImport,
+  filename: string,
+  order: number,
+): Promise<QuestionToImport> => {
+  const filepath = join(
+    COURSE_DIRECTORY,
+    lesson.course.slug,
+    "modules",
+    lesson.module.slug,
+    "lessons",
+    lesson.slug,
+    "questions",
+    filename,
+  );
+  const parsed = parse(filename);
+  const basename = parsed.name;
+
+  const raw = await readFile(filepath, "utf8");
+  // Header-only: avoids resolving body `include::` (unfilled attrs like `{cypher-repository-raw}`).
+  const file = loadFile(filepath, { parse_header_only: true });
+  const titleFromRaw = extractTitleFromRaw(raw);
+  const title =
+    ((file.getTitle() as string) || "").trim() || titleFromRaw;
+  const id = file.getAttribute(
+    "id",
+    generateQuestionId(
+      ((file.getDocumentTitle({ sanitize: true }) as string) || "").trim() ||
+        titleFromRaw ||
+        title,
+    ),
+  ) as string;
+  const stem = extractStem(raw);
+  const hint = extractTipBlock(raw, "hint");
+  const solution = extractTipBlock(raw, "solution");
+  const optionRows = extractChecklistOptions(raw);
+  const blockRole = detectBlockRole(raw);
+
+  const attrType = file.getAttribute("type", null) as string | null;
+  let type = attrType?.trim() || "";
+  if (!type) {
+    if (blockRole === "verify") {
+      type = "verify";
+    } else if (optionRows.length > 0) {
+      type = "multiple-choice";
+    } else {
+      type = "multiple-choice";
+    }
+  }
+
+  const answers: AnswerToImport[] = optionRows.map((opt, index) => ({
+    id: answerNodeId(lesson.link, id, index),
+    text: opt.text,
+    correct: opt.correct,
+    order: index,
+  }));
 
   return {
     id,
     filename: parsed.base,
-    text: file.getTitle(),
+    basename,
+    title,
+    text: stem,
     lessonLink: lesson.link,
-  } as QuestionToImport
-}
+    type,
+    hint,
+    solution,
+    order,
+    answers,
+  };
+};
 
-export default async function loadQuestions(lessons: LessonToImport[]): Promise<QuestionToImport[]> {
-  const output: QuestionToImport[] = []
+export default async function loadQuestions(
+  lessons: LessonToImport[],
+): Promise<QuestionToImport[]> {
+  const output: QuestionToImport[] = [];
   for (const lesson of lessons) {
     const questionDir = join(
-      COURSE_DIRECTORY, lesson.course.slug,
-      'modules', lesson.module.slug,
-      'lessons', lesson.slug,
-      'questions'
-    )
+      COURSE_DIRECTORY,
+      lesson.course.slug,
+      "modules",
+      lesson.module.slug,
+      "lessons",
+      lesson.slug,
+      "questions",
+    );
 
     if (existsSync(questionDir)) {
-      const questions = await readdir(questionDir)
-        .then(filenames => filenames.filter(
-          filename => filename.endsWith('.adoc')
-        ))
+      const filenames = (await readdir(questionDir)).filter((f) =>
+        f.endsWith(".adoc"),
+      );
+      filenames.sort((a, b) =>
+        a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" }),
+      );
 
-      for (const filename of questions) {
-        const question = await loadQuestion(lesson, filename)
-        output.push(question)
+      for (let o = 0; o < filenames.length; o++) {
+        const question = await loadQuestion(lesson, filenames[o], o);
+        output.push(question);
       }
     }
   }
 
-  return output
+  return output;
 }

--- a/src/services/load/tx.ts
+++ b/src/services/load/tx.ts
@@ -182,19 +182,84 @@ export const mergeLessonDetails = (tx: ManagedTransaction, lessons: any) =>
     { lessons },
   );
 
-export const mergeQuestionDetails = (tx: ManagedTransaction, questions: any) =>
-  tx.run(
+export const mergeQuestionDetails = async (
+  tx: ManagedTransaction,
+  questions: any,
+) => {
+  await tx.run(
     `
   UNWIND $questions AS question
   MATCH (l:Lesson {link: question.lessonLink})
 
   MERGE (q:Question {id: apoc.text.base64Encode(l.id +'--'+ question.id)})
-  SET q.slug = question.id, q.text = question.text, q.filename = question.filename
+  SET
+    q.slug = question.id,
+    q.title = question.title,
+    q.text = question.text,
+    q.filename = question.filename,
+    q.link = l.link + question.basename,
+    q.lessonLink = l.link,
+    q.type = question.type,
+    q.hint = question.hint,
+    q.solution = question.solution,
+    q.order = toInteger(question.order)
 
   REMOVE q:DeletedQuestion
   MERGE (l)-[:HAS_QUESTION]->(q)
+
+  WITH q, question, [x IN coalesce(question.answers, []) | x.id] AS validIds
+  MATCH (q)-[r:HAS_ANSWER]->(a:Answer)
+  WHERE NOT a.id IN validIds
+  SET a:DeletedAnswer
+  DELETE r
 `,
     { questions },
+  );
+
+  const answerRows = questions.flatMap((q: { answers?: unknown[]; lessonLink: string; id: string }) =>
+    (Array.isArray(q.answers) ? q.answers : []).map((a: any) => ({
+      lessonLink: q.lessonLink,
+      questionSlug: q.id,
+      id: a.id,
+      text: a.text,
+      correct: a.correct,
+      order: a.order,
+    })),
+  );
+
+  if (answerRows.length > 0) {
+    await tx.run(
+      `
+      UNWIND $rows AS row
+      MATCH (l:Lesson {link: row.lessonLink})
+      MERGE (q:Question {id: apoc.text.base64Encode(l.id +'--'+ row.questionSlug)})
+      MERGE (a:Answer {id: row.id})
+      SET a.text = row.text, a.correct = row.correct, a.order = toInteger(row.order)
+      REMOVE a:DeletedAnswer
+      MERGE (q)-[:HAS_ANSWER]->(a)
+    `,
+      { rows: answerRows },
+    );
+  }
+};
+
+export const markStaleQuestionsDeleted = (
+  tx: ManagedTransaction,
+  rows: { lessonLink: string; validQuestionIds: string[] }[],
+) =>
+  tx.run(
+    `
+    UNWIND $rows AS row
+    MATCH (q:Question)
+    WHERE q.lessonLink = row.lessonLink
+      AND NOT q.id IN row.validQuestionIds
+    SET q:DeletedQuestion
+    WITH q
+    MATCH (q)-[r:HAS_ANSWER]->(a:Answer)
+    SET a:DeletedAnswer
+    DELETE r
+    `,
+    { rows },
   );
 
 // Integrity Checks

--- a/src/services/sync-courses.ts
+++ b/src/services/sync-courses.ts
@@ -3,11 +3,13 @@ import { getDriver } from "../modules/neo4j";
 import {
   checkSchema,
   disableAllCourses,
+  markStaleQuestionsDeleted,
   mergeCourseDetails,
   mergeLessonDetails,
   mergeModuleDetails,
   mergeQuestionDetails,
 } from "./load/tx";
+import { questionNodeId } from "./load/graph-ids";
 import load from "./load";
 
 export async function syncCourses(): Promise<void> {
@@ -48,6 +50,7 @@ export async function syncCourses(): Promise<void> {
   });
   console.log(`   -- 📄 ${lessonCount} lessons`);
 
+  let answerMergeCount = 0;
   const questionCount = await session.executeWrite(async (tx) => {
     const remaining = questions.slice(0);
     const batchSize = 1000;
@@ -56,12 +59,27 @@ export async function syncCourses(): Promise<void> {
       const batch = remaining.splice(0, batchSize);
 
       await mergeQuestionDetails(tx, batch);
+      answerMergeCount += batch.reduce(
+        (n, q) => n + (q.answers?.length ?? 0),
+        0,
+      );
     }
 
     return questions.length;
   });
 
-  console.log(`   -- 🤨 ${questionCount} questions`);
+  console.log(`   -- 🤨 ${questionCount} questions (${answerMergeCount} answer rows merged)`);
+
+  await session.executeWrite(async (tx) => {
+    const staleRows = lessons.map((lesson) => ({
+      lessonLink: lesson.link,
+      validQuestionIds: questions
+        .filter((q) => q.lessonLink === lesson.link)
+        .map((q) => questionNodeId(lesson.link, q.id)),
+    }));
+    await markStaleQuestionsDeleted(tx, staleRows);
+  });
+  console.log(`   -- 🧹 Stale question/answer labels reconciled per lesson`);
 
   // Clean {FIRST|LAST|NEXT}_{MODULE|LESSON}
   await session.executeWrite(async (tx) => {


### PR DESCRIPTION
src/services/load/graph-ids.ts (new file)
  - Utility functions to generate base64-encoded Neo4j node IDs matching apoc.text.base64Encode — for Lesson,
   Question, and Answer nodes.

  src/services/load/load-questions.ts (heavily reworked)
  - QuestionToImport type expanded: now includes title, text (stem), lessonLink, type, hint, solution, order,
   and an answers array.
  - New AnswerToImport type added and re-exported.
  - Raw .adoc file parsing added: extracts the question stem, checklist answer options (with
  correct/incorrect flags), [TIP, role=hint] / [TIP, role=solution] blocks, and question type (verify,
  multiple-choice).
  - File ordering is now deterministic (locale sort with numeric sensitivity).

  src/services/load/tx.ts
  - mergeQuestionDetails made async; now sets many more properties on Question nodes (title, link,
  lessonLink, type, hint, solution, order) and handles stale answer cleanup within the same transaction.
  - Second Cypher run merges Answer nodes with HAS_ANSWER relationships.
  - New markStaleQuestionsDeleted export: marks questions (and their answers) as
  DeletedQuestion/DeletedAnswer if they're no longer present for a lesson.

  src/services/sync-courses.ts
  - Wires in markStaleQuestionsDeleted after the question merge to reconcile stale data per lesson.
  - Logs answer merge count alongside question count.

