### PR TITLE
GRAC-198 -- workshop-fundamentals -- LIMIT updates

### DIFF
--- a/asciidoc/courses/workshop-fundamentals/modules/2-cypher-fundamentals/lessons/1-matching-data/lesson.adoc
+++ b/asciidoc/courses/workshop-fundamentals/modules/2-cypher-fundamentals/lessons/1-matching-data/lesson.adoc
@@ -29,6 +29,7 @@ You can use a pattern to find data using the `MATCH` clause:
 ----
 MATCH (m:Movie)-[:IN_GENRE]->(g:Genre {name: "Action"})
 RETURN m.title, g.name
+LIMIT 100
 ----
 
 [.slide]
@@ -41,6 +42,7 @@ For example, finding all the actors in action movies:
 ----
 MATCH (actor:Person)-[:ACTED_IN]->(m:Movie)-[:IN_GENRE]->(g:Genre {name: "Action"})
 RETURN actor.name, m.title, g.name
+LIMIT 100
 ----
 
 [.slide]
@@ -55,6 +57,7 @@ Finding the directors of action movies:
 MATCH (actor:Person)-[:ACTED_IN]->(m:Movie)-[:IN_GENRE]->(g:Genre {name: "Action"})
 MATCH (m)<-[:DIRECTED]-(director:Person)
 RETURN actor.name, director.name, m.title, g.name
+LIMIT 100
 ----
 
 [.slide]
@@ -72,6 +75,7 @@ Any movie that does not have a rating will return `null` for the user's name and
 MATCH (m:Movie)-[:IN_GENRE]->(g:Genre {name: "Film-Noir"})
 OPTIONAL MATCH (m)<-[r:RATED]-(u:User)
 RETURN m.title, u.name, r.rating
+LIMIT 100
 ----
 
 [.slide]
@@ -99,6 +103,7 @@ You can use the `AS` keyword to give a name to the data you are returning.
 ----
 MATCH (m:Movie)-[:IN_GENRE]->(g:Genre)
 RETURN m.title AS movieTitle, g.name AS genre
+LIMIT 100
 ----
 
 [.slide]
@@ -112,7 +117,7 @@ Complete the queries to find the following data in the graph:
 ====
 [source, cypher]
 ----
-MATCH (m:??????) RETURN m.title AS movieTitle
+MATCH (m:?????? {title:"????") RETURN m.title AS movieTitle
 ----
 ====
 . Use the `ACTED_IN` relationship to find who acted in that movie.
@@ -145,7 +150,7 @@ RETURN p.name AS director
 +
 [source, cypher]
 ----
-MATCH (m:Movie) RETURN m.title AS movieTitle
+MATCH (m:Movie {title: "?movieTitle?") RETURN m.title AS movieTitle
 ----
 
 . Use the `ACTED_IN` relationship to find who acted in that movie.

--- a/asciidoc/courses/workshop-fundamentals/modules/2-cypher-fundamentals/lessons/3-ordering-limits/lesson.adoc
+++ b/asciidoc/courses/workshop-fundamentals/modules/2-cypher-fundamentals/lessons/3-ordering-limits/lesson.adoc
@@ -78,6 +78,7 @@ RETURN m.title, m.released
 [source, cypher]
 ----
 MATCH (m:Movie)
+WHERE m.released IS NOT NULL
 ????? ?? m.released ????
 RETURN m.title, m.released
 ????? 10
@@ -103,6 +104,7 @@ RETURN m.title, m.released
 [source, cypher]
 ----
 MATCH (m:Movie)
+WHERE m.released IS NOT NULL
 ORDER BY m.released DESC
 RETURN m.title, m.released
 LIMIT 10

--- a/asciidoc/courses/workshop-fundamentals/modules/2-cypher-fundamentals/lessons/4-aggregation/lesson.adoc
+++ b/asciidoc/courses/workshop-fundamentals/modules/2-cypher-fundamentals/lessons/4-aggregation/lesson.adoc
@@ -90,6 +90,7 @@ MATCH (m:Movie)<-[r:RATED]-()
 RETURN
     m.title AS movieTitle,
     avg(r.rating) AS avgRating
+LIMIT 1000
 ----
 
 [.slide.discrete]
@@ -123,6 +124,7 @@ RETURN
     m.title AS movieTitle,
     ?????(??????) as actorCount
 ORDER BY ?????? ????
+LIMIT 100
 ----
 ====
 . What is the highest rated movie starring "Tom Hanks".
@@ -154,6 +156,7 @@ RETURN
     m.title AS movieTitle,
     count(p) as actorCount
 ORDER by actorCount DESC
+LIMIT 100
 ----
 . Find the highest rated movie starring "Tom Hanks".
 +

--- a/asciidoc/courses/workshop-fundamentals/modules/2-cypher-fundamentals/lessons/5-with/lesson.adoc
+++ b/asciidoc/courses/workshop-fundamentals/modules/2-cypher-fundamentals/lessons/5-with/lesson.adoc
@@ -30,6 +30,7 @@ WITH u, m
 MATCH (u)-[r:RATED]->(other:Movie)
 WHERE other <> m
 RETURN u.name, other.title, r.rating
+LIMIT 1000
 ----
 
 [.slide]


### PR DESCRIPTION
## General Update PR

## Description

Several example queries in workshop-fundamentals are crashing the browser. Adding LIMIT appears to improve, if not completely fix, the bug. Added LIMIT to queries with large returns.

Other:

Added a null check to 3-ordering-limits where the following query returned all null values:

`MATCH (m:Movie)
ORDER BY m.released DESC
RETURN m.title, m.released`

## Related Issues

- Closes GRAC-198

## Testing

- [x] Tested locally
- [x] All existing tests pass
