### PR TITLE
Dashboards april update

### DIFF
--- a/asciidoc/courses/aura-agents/course.adoc
+++ b/asciidoc/courses/aura-agents/course.adoc
@@ -29,7 +29,7 @@ In this course, you will discover Aura Agent, learn how to design and build no/l
 == Prerequisites
 
 
-To get the most from this course, have an AuraDB instance with data loaded before you start. We also recommend completing the following courses:
+To get the most from this course, have an AuraDB instance with data loaded before you start. Complete the following courses first:
 
 * link:/courses/aura-fundamentals/[Aura Fundamentals^] - Create and manage Aura instances
 * link:/courses/neo4j-fundamentals/[Neo4j Fundamentals^] - Understand graph database concepts

--- a/asciidoc/courses/aura-dashboards/course.adoc
+++ b/asciidoc/courses/aura-dashboards/course.adoc
@@ -2,38 +2,44 @@
 :categories: administrator:1, aura:2, foundation:1, intermediate:21, deploy-with-aura:3, coredb
 :status: active
 :duration: 2 hours
-:caption: Learn about data visualization in Neo4j.
-:key-points: Neo4j Dashboards, exploratory data analysis, data import and visualization, exploring relationships in data.
+:caption: Learn to build and share dashboards in Neo4j Aura
+:usecase: blank-sandbox
+:key-points: Neo4j Dashboards, Aura Console, building dashboards with AI and Cypher, Movies sample dataset, sharing dashboards
 
 
-In this course you will learn about Neo4j Aura Dashboards, the tool in the Aura console that turns your graph data into visualizations and lets you share them.
+== Course Description
 
-The course uses the Movies dataset so you can follow along with the same data as in Neo4j Fundamentals, Graph Data Modeling Fundamentals, and Aura Fundamentals.
+In this course, you will use Neo4j Aura Dashboards to visualize graph data, build dashboard cards with AI and Cypher, and share dashboards with others.
 
-By the end of this course, you will be able to connect to Neo4j Dashboards from Aura, load the Movies dataset, create and style dashboard cards with AI and Cypher, choose the right chart types for your data, and share your dashboard with others.
-
-== What you will learn
-
-* Access Neo4j Dashboards from Aura and connect to your instance
-* Create cards with natural language (AI) or with Cypher
-* Style cards and choose chart types: graph, table, bar, pie, single value
-* Share your dashboard with others
 
 == Duration
 
 {duration}
 
+
+== What you will learn
+
+* Understand what Neo4j Dashboards are, when to use them, and how they connect to AuraDB
+* Connect Dashboards to your instance; load the Movies sample or use your own graph
+* Build a dashboard: map questions to your model, add cards with AI and Cypher, organize pages, and use filters and aggregations
+* Style cards, choose chart types, and import or export dashboard JSON when you need to move or back up a layout
+* Share your dashboard with project users and apply roles that match how people should interact with the data
+
+
 == Prerequisites
 
-Before starting this course, you should have a basic understanding of Neo4j. If you are new to Neo4j, familiarize yourself with the following courses:
 
-* link:/courses/neo4j-fundamentals/[Neo4j Fundamentals course^] - Learn the basics of graph databases and Neo4j
-* link:/courses/aura-fundamentals/[Aura Fundamentals course^] - Learn how to create and manage Aura instances, including signing up for an account and creating your first instance
-* link:/courses/cypher-fundamentals/[Cypher Fundamentals course^] - Learn the Cypher query language
+To get the most from this course, have an AuraDB instance with data loaded before you start. We also recommend completing the following courses:
+
+* link:/courses/aura-fundamentals/[Aura Fundamentals^] - Create and manage Aura instances
+* link:/courses/neo4j-fundamentals/[Neo4j Fundamentals^] - Understand graph database concepts
+* link:/courses/cypher-fundamentals/[Cypher Fundamentals^] - Query language basics
 
 
 [.includes]
 == This course includes
 
-* [lessons]#10 lessons#
-* [quizes]#8 multiple choice quizzes#
+* [modules]#3 modules#
+* [lessons]#11 lessons#
+* [challenges]#4 hands-on challenges#
+* [quizes]#quizzes to support your learning#

--- a/asciidoc/courses/aura-dashboards/course.adoc
+++ b/asciidoc/courses/aura-dashboards/course.adoc
@@ -29,7 +29,7 @@ In this course, you will use Neo4j Aura Dashboards to visualize graph data, buil
 == Prerequisites
 
 
-To get the most from this course, have an AuraDB instance with data loaded before you start. We also recommend completing the following courses:
+To get the most from this course, have an AuraDB instance with data loaded before you start. Complete the following courses first:
 
 * link:/courses/aura-fundamentals/[Aura Fundamentals^] - Create and manage Aura instances
 * link:/courses/neo4j-fundamentals/[Neo4j Fundamentals^] - Understand graph database concepts
@@ -40,6 +40,6 @@ To get the most from this course, have an AuraDB instance with data loaded befor
 == This course includes
 
 * [modules]#3 modules#
-* [lessons]#11 lessons#
+* [lessons]#14 lessons#
 * [challenges]#4 hands-on challenges#
 * [quizes]#quizzes to support your learning#

--- a/asciidoc/courses/aura-dashboards/modules/1-getting-started/lessons/1-what-are-dashboards/lesson.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/1-getting-started/lessons/1-what-are-dashboards/lesson.adoc
@@ -1,7 +1,7 @@
 = Understanding Neo4j Dashboards
-:type: lesson
 :order: 1
-// Image note: use current Dashboards UI screenshots (not NeoDash). Optional: add a short intro video.
+:type: lesson
+// TODO: Screenshot — Aura Console left nav with **Dashboards** highlighted (current Neo4j Dashboards UI, not legacy NeoDash).
 
 [.slide.discrete]
 == What are Neo4j Dashboards?
@@ -9,30 +9,26 @@
 In this lesson you will learn:
 
 * What Neo4j Dashboards are and when to use them
-* What you need to run Dashboards
+* Prerequisites to use Dashboards in Aura (including sample graph data)
 * What a dashboard looks like (example chart and natural language)
-
-== What you need
-
-You need a Neo4j instance: Aura or Desktop. New to Neo4j? See link:/courses/neo4j-fundamentals/[Neo4j Fundamentals^], link:/courses/aura-fundamentals/[Aura Fundamentals^], or link:/courses/cypher-fundamentals/[Cypher Fundamentals^].
 
 == Introducing Neo4j Dashboards
 
-Neo4j Dashboards is a tool for visualizing and exploring your graph data. Using the Movies dataset, you will learn to build dashboards that visualize insights about movies, actors, ratings, and relationships.
+Neo4j Dashboards is a tool for visualizing and exploring your graph data. You build your own dashboards against the data in your AuraDB instance.
 
 Dashboards help you:
 
-* Visualize patterns in ratings and movie popularity
-* Monitor trends in genre preferences and actor collaborations
-* Share insights with stakeholders (content teams, marketing, executives)
-* Explore data interactively without writing complex queries
-* Make data-driven decisions based on visual insights
+* Visualize patterns and relationships in your domain
+* Monitor trends and compare categories or entities
+* Share insights with stakeholders
+* Explore data interactively without writing every query from scratch
+* Support decisions using charts tied to your graph
 
-Use the **Natural Language** feature in the card editor to ask questions about your movie data (for example, "Show average rating by genre" or "Visualize actor relationships"), and Neo4j Dashboards will generate the Cypher queries and visualizations for you.
+Use the **Natural Language** feature in the card editor to describe what you want to see (for example, "Show average rating by genre" or "Visualize actor relationships" when you use the sample data), and Neo4j Dashboards will generate Cypher and visualizations for you.
 
-**The Movies dataset:** Throughout this course you will work with the same Movies dataset used in the Neo4j Fundamentals, Graph Data Modeling Fundamentals, and Aura Fundamentals courses. This dataset contains information about movies, actors, directors, genres, and ratings, which is what you need for building dashboards.
+The examples that follow use the Movies recommendations graph in queries and screenshots. When you use your own labels and relationships, substitute your schema and adapt the prompts and Cypher.
 
-In this course, you will learn how to build dashboards similar to the one below using the Movies dataset:
+You can build dashboards similar to the one below (Movies example):
 
 image::images/dashboards.png[Neo4j Dashboards example,width=600,align=center]
 
@@ -45,6 +41,77 @@ Below is an example of a card created with natural language:
 
 video::https://cdn.graphacademy.neo4j.com/courses/aura-dashboards-videos/movies-by-decade-natural-language.mp4["Average rating by genre",role="cdn", width=100%]
 
+== Prerequisites to use Neo4j Dashboards
+
+Neo4j Dashboards runs in the link:https://console.neo4j.io[Aura Console^] and reads graph data from your AuraDB instance. Before you connect in the next lesson, make sure you have:
+
+* **Graph data** — Dashboards charts whatever is in the database. If your instance is empty, load the sample dataset in <<sample-graph-data,Sample graph data>> below (or bring your own graph and run `CALL db.schema.visualization` in **Query** to inspect it).
+* **Access to Dashboards** — Open **Dashboards** from the left navigation. Your Aura tier limits how many dashboards you can create; the next lesson summarizes limits.
+
+New to Neo4j or Aura? See link:/courses/aura-dashboards/#_prerequisites[the prerequisites for this course^] for recommended courses covering graph concepts, Cypher, and the Console.
+
+[[sample-graph-data]]
+=== Sample graph data
+
+This course uses the **Movies recommendations** dataset: roughly 9,000 movies, people (actors and directors), genres, users, and ratings — about 28,000 nodes and 166,000 relationships. The schema:
+
+----
+(:User)-[:RATED]->(:Movie)
+(:Person:Actor)-[:ACTED_IN]->(:Movie)
+(:Person:Director)-[:DIRECTED]->(:Movie)
+(:Movie)-[:IN_GENRE]->(:Genre)
+----
+
+==== Step 1: Get the dataset
+
+The files are hosted on GitHub:
+
+link:https://github.com/neo4j-graph-examples/recommendations[neo4j-graph-examples/recommendations^, role=btn]
+
+Open the repository, go to the **data/** folder, and download the latest `.dump` file.
+
+==== Step 2: Restore it into your Aura instance
+
+// TODO: Screenshot — Instance detail view showing **Backup & Restore** and the **Restore** tab with **Upload file** (replace when Aura UI changes).
+
+. In the Aura Console, open your instance
+. Click **Backup & Restore** in the instance panel
+. Select the **Restore** tab
+. Click **Upload file** and select the `.dump` file you downloaded
+. Confirm — this replaces all existing data in the instance
+
+video::https://cdn.graphacademy.neo4j.com/courses/aura-dashboards-videos/load-movie-data.mp4["Load Movie Data",role="cdn", width=100%]
+
+The instance restarts automatically once the restore completes. For more detail, see link:https://neo4j.com/docs/aura/[Neo4j Aura documentation^] (search for backup and restore).
+
+[%collapsible]
+.Alternative: smaller CSV import
+====
+If you prefer not to restore a dump, link:https://raw.githubusercontent.com/neo4j-contrib/training/refs/heads/master/advanced_cypher/data/movies.csv[download movies.csv^], open **Query** or **Import** in the Console, and load it with `LOAD CSV` or the Import mapper. That loads a smaller movies-and-actors graph; adapt later examples if some labels are missing.
+====
+
+==== Step 3: Verify the data
+
+// TODO: Screenshot — **Query** with `CALL db.schema.visualization` graph result (or table) showing Movie, Person, User, Genre.
+
+Open **Query**, connect to your instance, and run:
+
+[source,cypher]
+----
+CALL db.schema.visualization
+----
+
+You should see `Movie`, `Person`, `User`, and `Genre` nodes connected by `RATED`, `ACTED_IN`, `DIRECTED`, and `IN_GENRE` relationships.
+
+video::https://cdn.graphacademy.neo4j.com/courses/aura-dashboards-videos/explore-loaded-data.mp4["Explore Loaded Data",role="cdn", width=100%]
+
+== Before you connect in the next lesson
+
+Quick checks:
+
+. Log in to link:https://console.neo4j.io/[Neo4j Aura^]. If you need an account or database, follow link:https://neo4j.com/docs/aura/classic/auradb/getting-started/create-database/[Getting started with Aura^].
+. Spot **Dashboards** in the left nav—you will use it next.
+. If you want a sanity check, open **Query**, connect to your instance, and run `RETURN 1 AS ready`.
 
 [.quiz]
 == Check your understanding
@@ -54,4 +121,4 @@ include::questions/1-purpose.adoc[leveloffset=+1]
 [.summary]
 == Summary
 
-You saw what Neo4j Dashboards is, what you need to run it, and how a card can be created from natural language. In the next lesson you will open Dashboards and connect to your instance.
+You know what Neo4j Dashboards is for, how to prepare graph data for the exercises, and what an AI-generated card looks like. Next, open Dashboards in Aura and connect to your instance.

--- a/asciidoc/courses/aura-dashboards/modules/1-getting-started/lessons/1-what-are-dashboards/lesson.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/1-getting-started/lessons/1-what-are-dashboards/lesson.adoc
@@ -9,8 +9,7 @@
 In this lesson you will learn:
 
 * What Neo4j Dashboards are and when to use them
-* Prerequisites to use Dashboards in Aura (including sample graph data)
-* What a dashboard looks like (example chart and natural language)
+* What a dashboard card can look like (example chart and natural language)
 
 == Introducing Neo4j Dashboards
 
@@ -41,71 +40,13 @@ Below is an example of a card created with natural language:
 
 video::https://cdn.graphacademy.neo4j.com/courses/aura-dashboards-videos/movies-by-decade-natural-language.mp4["Average rating by genre",role="cdn", width=100%]
 
-== Prerequisites to use Neo4j Dashboards
+== Before you load data
 
-Neo4j Dashboards runs in the link:https://console.neo4j.io[Aura Console^] and reads graph data from your AuraDB instance. Before you connect in the next lesson, make sure you have:
+You need a Neo4j AuraDB instance with **graph data** before you can build meaningful cards. The next lesson shows how to restore the **Movies recommendations** dataset if your database is empty. If you already loaded data, you can skip that lesson and go straight to **Dashboards** after link:/courses/aura-dashboards/1-getting-started/2-load-sample-data/[Load the Movies recommendations dataset^].
 
-* **Graph data** — Dashboards charts whatever is in the database. If your instance is empty, load the sample dataset in <<sample-graph-data,Sample graph data>> below (or bring your own graph and run `CALL db.schema.visualization` in **Query** to inspect it).
-* **Access to Dashboards** — Open **Dashboards** from the left navigation. Your Aura tier limits how many dashboards you can create; the next lesson summarizes limits.
+New to Neo4j or Aura? Open link:/courses/aura-dashboards/#_prerequisites[the prerequisites for this course^] and complete the courses listed there. They cover graph concepts, Cypher, and the Console.
 
-New to Neo4j or Aura? See link:/courses/aura-dashboards/#_prerequisites[the prerequisites for this course^] for recommended courses covering graph concepts, Cypher, and the Console.
-
-[[sample-graph-data]]
-=== Sample graph data
-
-This course uses the **Movies recommendations** dataset: roughly 9,000 movies, people (actors and directors), genres, users, and ratings — about 28,000 nodes and 166,000 relationships. The schema:
-
-----
-(:User)-[:RATED]->(:Movie)
-(:Person:Actor)-[:ACTED_IN]->(:Movie)
-(:Person:Director)-[:DIRECTED]->(:Movie)
-(:Movie)-[:IN_GENRE]->(:Genre)
-----
-
-==== Step 1: Get the dataset
-
-The files are hosted on GitHub:
-
-link:https://github.com/neo4j-graph-examples/recommendations[neo4j-graph-examples/recommendations^, role=btn]
-
-Open the repository, go to the **data/** folder, and download the latest `.dump` file.
-
-==== Step 2: Restore it into your Aura instance
-
-// TODO: Screenshot — Instance detail view showing **Backup & Restore** and the **Restore** tab with **Upload file** (replace when Aura UI changes).
-
-. In the Aura Console, open your instance
-. Click **Backup & Restore** in the instance panel
-. Select the **Restore** tab
-. Click **Upload file** and select the `.dump` file you downloaded
-. Confirm — this replaces all existing data in the instance
-
-video::https://cdn.graphacademy.neo4j.com/courses/aura-dashboards-videos/load-movie-data.mp4["Load Movie Data",role="cdn", width=100%]
-
-The instance restarts automatically once the restore completes. For more detail, see link:https://neo4j.com/docs/aura/[Neo4j Aura documentation^] (search for backup and restore).
-
-[%collapsible]
-.Alternative: smaller CSV import
-====
-If you prefer not to restore a dump, link:https://raw.githubusercontent.com/neo4j-contrib/training/refs/heads/master/advanced_cypher/data/movies.csv[download movies.csv^], open **Query** or **Import** in the Console, and load it with `LOAD CSV` or the Import mapper. That loads a smaller movies-and-actors graph; adapt later examples if some labels are missing.
-====
-
-==== Step 3: Verify the data
-
-// TODO: Screenshot — **Query** with `CALL db.schema.visualization` graph result (or table) showing Movie, Person, User, Genre.
-
-Open **Query**, connect to your instance, and run:
-
-[source,cypher]
-----
-CALL db.schema.visualization
-----
-
-You should see `Movie`, `Person`, `User`, and `Genre` nodes connected by `RATED`, `ACTED_IN`, `DIRECTED`, and `IN_GENRE` relationships.
-
-video::https://cdn.graphacademy.neo4j.com/courses/aura-dashboards-videos/explore-loaded-data.mp4["Explore Loaded Data",role="cdn", width=100%]
-
-== Before you connect in the next lesson
+== Before you connect
 
 Quick checks:
 
@@ -121,4 +62,4 @@ include::questions/1-purpose.adoc[leveloffset=+1]
 [.summary]
 == Summary
 
-You know what Neo4j Dashboards is for, how to prepare graph data for the exercises, and what an AI-generated card looks like. Next, open Dashboards in Aura and connect to your instance.
+You know what Neo4j Dashboards is for and what an AI-generated card looks like. Next, load the recommendations dataset (or confirm your own graph), then open Dashboards and connect.

--- a/asciidoc/courses/aura-dashboards/modules/1-getting-started/lessons/2-accessing-aura-dashboards/lesson.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/1-getting-started/lessons/2-accessing-aura-dashboards/lesson.adoc
@@ -1,9 +1,9 @@
 = Accessing Neo4j Dashboards
-:order: 2
+:order: 3
 :type: lesson
 
 
-In the previous lesson you learned what Neo4j Dashboards are and what you need to run them. In this lesson you will learn:
+In the previous lesson you loaded the Movies recommendations dataset (or confirmed your own graph). In this lesson you will learn:
 
 * How to access Neo4j Dashboards from Aura
 * Dashboard limits per tier

--- a/asciidoc/courses/aura-dashboards/modules/1-getting-started/lessons/2-accessing-aura-dashboards/lesson.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/1-getting-started/lessons/2-accessing-aura-dashboards/lesson.adoc
@@ -1,6 +1,6 @@
 = Accessing Neo4j Dashboards
-:type: lesson
 :order: 2
+:type: lesson
 
 
 In the previous lesson you learned what Neo4j Dashboards are and what you need to run them. In this lesson you will learn:
@@ -15,9 +15,7 @@ To explore the Dashboards UI, you need a Neo4j instance to connect to.
 
 **If you already have an instance**, skip to <<Step 1: Connect to an instance>>.
 
-**If you need to create an account and instance**, see the link:/courses/aura-fundamentals/1-introduction/3-sign-up/[Sign up for Aura lesson^] in the Aura Fundamentals course for detailed step-by-step instructions.
-
-For documentation on creating an account and instance, see link:https://neo4j.com/docs/aura/classic/auradb/getting-started/create-database/[Create Database documentation^].
+**If you need to create an account and instance**, follow link:https://neo4j.com/docs/aura/classic/auradb/getting-started/create-database/[Getting started with Aura^] in the Neo4j documentation.
 
 [NOTE]
 .Using the Professional tier
@@ -58,6 +56,8 @@ image::images/ee-dashboards.png[Paid tier dashboards,width=600,align=center]
 [[step-1]]
 == Step 1: Connect to an instance
 
+// TODO: Screenshot — **Connect to instance** flow if the existing `dashboards-ui.png` / `connect-from-dashboards.png` pair drifts from current UI; re-capture both.
+
 To connect to your instance from the Dashboards UI:
 
 . Log in to your account and go to the **Dashboards** menu
@@ -72,14 +72,17 @@ image::images/connect-from-dashboards.png[Connect to instance dialog,width=600,a
 [NOTE]
 .Finding your connection details
 ====
-For detailed information on how to retrieve your connection URI, username, and password, see the link:/courses/aura-fundamentals/2-getting-started/5-connecting/[Connecting to your instance lesson^] in the Aura Fundamentals course.
-
-Find your connection details by clicking the **...** menu next to your instance name and selecting **Inspect**, or use the credentials file downloaded when you created the instance.
+Retrieve your connection URI, username, and password from the Aura Console: open the **...** menu next to your instance and select **Inspect**, or use the credentials file from when you created the instance. See link:https://neo4j.com/docs/aura/classic/auradb/connecting-applications/[Connecting to Aura^] in the documentation for details.
 ====
 
 For more information on connecting to Dashboards, see link:https://neo4j.com/docs/aura/dashboards/[Neo4j Dashboards documentation^].
 
+== Check that Dashboards sees your instance
 
+. Open **Dashboards** in the left menu.
+. Use **Connect to instance** with the same database you use in **Query**.
+. You should land on an empty or welcome screen—fine; you have not built pages yet.
+. Glance at the tier table above so you know how many dashboards your plan allows (Free caps at three).
 
 
 [.quiz]
@@ -91,9 +94,6 @@ include::questions/1-choosing.adoc[leveloffset=+1]
 [.summary]
 == Summary
 
-In this lesson you set up an Aura instance if you did not already have one and accessed Neo4j Dashboards.
+In this lesson you created an instance if you needed one and connected Dashboards to it.
 
-In the next lesson, you will learn how to:
-
-* Load data into your instance
-* Generate a demo dashboard using AI
+In the next lesson, you will create your first dashboard using AI and explore the Dashboards interface.

--- a/asciidoc/courses/aura-dashboards/modules/1-getting-started/lessons/2-accessing-aura-dashboards/questions/1-choosing.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/1-getting-started/lessons/2-accessing-aura-dashboards/questions/1-choosing.adoc
@@ -1,7 +1,7 @@
 [.question]
 = Dashboard limits on Free tier
 
-You are building a movies dashboard and want separate dashboard pages for different views, such as content team, marketing, and executives. You are on the AuraDB Free tier. How many dashboards can you create on Free tier?
+You are building a dashboard and want separate dashboard pages for different views, such as content team, marketing, and executives. You are on the AuraDB Free tier. How many dashboards can you create on Free tier?
 
 * [ ] 1 dashboard
 * [x] 3 dashboards

--- a/asciidoc/courses/aura-dashboards/modules/1-getting-started/lessons/2-load-sample-data/lesson.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/1-getting-started/lessons/2-load-sample-data/lesson.adoc
@@ -1,0 +1,67 @@
+= Load the Movies recommendations dataset
+:order: 2
+:type: lesson
+
+In the previous lesson you saw what Neo4j Dashboards are for. This lesson has **one focus:** get the **Movies recommendations** graph into your AuraDB instance so every later exercise matches the same labels and relationships.
+
+If your instance already has the graph you want to chart, run `CALL db.schema.visualization` in **Query** to confirm labels, then skip to link:/courses/aura-dashboards/1-getting-started/3-accessing-aura-dashboards/[Accessing Neo4j Dashboards^].
+
+[[sample-graph-data]]
+== Sample graph data
+
+Roughly 9,000 movies, people (actors and directors), genres, users, and ratings — about 28,000 nodes and 166,000 relationships. The schema:
+
+----
+(:User)-[:RATED]->(:Movie)
+(:Person:Actor)-[:ACTED_IN]->(:Movie)
+(:Person:Director)-[:DIRECTED]->(:Movie)
+(:Movie)-[:IN_GENRE]->(:Genre)
+----
+
+=== Step 1: Get the dataset
+
+link:https://github.com/neo4j-graph-examples/recommendations[neo4j-graph-examples/recommendations^, role=btn]
+
+Open the repository, go to the **data/** folder, and download the latest `.dump` file.
+
+=== Step 2: Restore it into your Aura instance
+
+// TODO: Screenshot — Instance detail view showing **Backup & Restore** and the **Restore** tab with **Upload file** (replace when Aura UI changes).
+
+. In the Aura Console, open your instance
+. Click **Backup & Restore** in the instance panel
+. Select the **Restore** tab
+. Click **Upload file** and select the `.dump` file you downloaded
+. Confirm — this replaces all existing data in the instance
+
+video::https://cdn.graphacademy.neo4j.com/courses/aura-dashboards-videos/load-movie-data.mp4["Load Movie Data",role="cdn", width=100%]
+
+The instance restarts automatically once the restore completes. For more detail, see link:https://neo4j.com/docs/aura/[Neo4j Aura documentation^] (search for backup and restore).
+
+[%collapsible]
+.Alternative: smaller CSV import
+====
+If you prefer not to restore a dump, link:https://raw.githubusercontent.com/neo4j-contrib/training/refs/heads/master/advanced_cypher/data/movies.csv[download movies.csv^], open **Query** or **Import** in the Console, and load it with `LOAD CSV` or the Import mapper. That loads a smaller movies-and-actors graph; adapt later examples if some labels are missing.
+====
+
+=== Step 3: Verify the data
+
+// TODO: Screenshot — **Query** with `CALL db.schema.visualization` graph result (or table) showing Movie, Person, User, Genre.
+
+Open **Query**, connect to your instance, and run:
+
+[source,cypher]
+----
+CALL db.schema.visualization
+----
+
+You should see `Movie`, `Person`, `User`, and `Genre` nodes connected by `RATED`, `ACTED_IN`, `DIRECTED`, and `IN_GENRE` relationships.
+
+video::https://cdn.graphacademy.neo4j.com/courses/aura-dashboards-videos/explore-loaded-data.mp4["Explore Loaded Data",role="cdn", width=100%]
+
+read::Mark as completed[]
+
+[.summary]
+== Summary
+
+Your AuraDB instance now holds the recommendations graph (or you confirmed your own). Next: open Dashboards in the Console and connect.

--- a/asciidoc/courses/aura-dashboards/modules/1-getting-started/lessons/3-exploring-dashboards/lesson.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/1-getting-started/lessons/3-exploring-dashboards/lesson.adoc
@@ -1,73 +1,21 @@
 = Exploring Dashboards
-:type: lesson
 :order: 3
+:type: lesson
 
-In the previous lesson you connected to your instance from the Dashboards UI. In this lesson you will learn:
+In the previous lesson you connected to your instance from the Dashboards UI. You should already have graph data in that instance (see link:/courses/aura-dashboards/1-getting-started/1-what-are-dashboards/#sample-graph-data[Sample graph data^] in the first lesson if you still need to load the Movies recommendations dataset). In this lesson you will learn:
 
-* How to load the Movies dataset into your instance
 * How to create your first dashboard with AI
 * How to explore the Dashboards interface
 
 You will have a dashboard ready to build on in the next module.
 
-== Loading the Movies dataset
-
-Load the Movies dataset before creating dashboard cards. Download the script from the link below, then run it in the Query tool.
-
-[NOTE]
-.If you need to create an Aura account
-====
-If you don't have a Neo4j Aura account yet, see the link:/courses/aura-fundamentals/1-introduction/3-sign-up/[Sign up for Aura lesson^] in the Aura Fundamentals course for detailed step-by-step instructions on creating an account and setting up your first instance.
-====
-
-[NOTE]
-.Movie data
-====
-The sample data should be _loaded_ into your database using the Movies Cypher script linked in Step 2 below, not the Import service.
-====
-
-The Movies dataset contains movies, actors, directors, genres, and ratings. That is exactly what you need to build dashboards that visualize insights.
-
-=== Step 1: Open the Query tool
-
-To load data using a Cypher script, connect to the Query tool:
-
-. In the console, click **Query** in the left menu
-. Connect to your instance using your credentials
-. Enter your connection details in the connection dialog
-
-Any Cypher script you run will execute against the connected Neo4j instance.
-
-=== Step 2: Load the sample data
-
-. Download the Movies dataset script: link:https://raw.githubusercontent.com/neo4j-graph-examples/movies/main/scripts/movies.cypher[movies.cypher^]. Alternatively, open link:https://github.com/neo4j-graph-examples/movies/blob/main/scripts/movies.cypher[on GitHub^] and click **Raw** to copy the script.
-. Copy the script contents into the Query Editor
-. Click **Run** to execute it
-
-video::https://cdn.graphacademy.neo4j.com/courses/aura-dashboards-videos/load-movie-data.mp4["Load Movie Data",role="cdn", width=100%]
-
-Once the script has finished running, you will see a summary of the nodes and relationships created in your Aura instance.
-
-=== Step 3: Verify the data
-
-Run this command to view the database schema:
-
-[source,cypher]
-----
-CALL db.schema.visualization
-----
-
-This will display a visualization of the database schema, showing the nodes and relationships that have been created.
-
-In the Query tool results, view the graph visualization of your schema.
-
-Go to the Explore tab to visualize and explore the data you have just loaded:
-
-video::https://cdn.graphacademy.neo4j.com/courses/aura-dashboards-videos/explore-loaded-data.mp4["Explore Loaded Data",role="cdn", width=100%]
-
 == Creating your first dashboard with AI
 
-With the Movies data loaded, create your first dashboard using AI.
+// TODO: Screenshot — **Create dashboard** → **Create with AI** entry point (menu or button as shown in current Console).
+// TODO: Screenshot — AI disclaimer / terms dialog before first generation (if still shown).
+// TODO: Screenshot — Generated dashboard canvas with at least one card (supplements the video below).
+
+With your graph ready, create your first dashboard using AI.
 
 . Go to **Dashboards** in the left menu
 . Click **Create dashboard** → **Create with AI**
@@ -85,9 +33,18 @@ Take time to explore the different cards and visualizations before continuing to
 The **Create with AI** feature is only available in the Neo4j Aura Console, and not available in Neo4j Desktop.
 ====
 
-*Challenge*
+== Build your first dashboard now
 
-Load the Movies dataset when you do not already have it, then create your first dashboard with AI. Use a prompt that asks for something specific, such as "Average rating by genre" or "Actors and the movies they acted in." Explore the cards the AI generates, then add one more card with a different prompt, for example "Top 10 rated movies." When you are done, you are ready for the next module.
+// TODO: Screenshot — Card editor with **Visualization type** and Cypher visible (learner “peek” step).
+
+. If you are not sure what is in the graph, run `CALL db.schema.visualization` in **Query** once. If the instance is empty, load data using link:/courses/aura-dashboards/1-getting-started/1-what-are-dashboards/#sample-graph-data[Sample graph data^] in the first lesson.
+. In **Dashboards**, start **Create with AI**, accept the disclaimer, and generate something concrete — "Average rating by genre" is a solid first prompt for the recommendations data.
+. Click through the cards it made. Peek at **Visualization type** (and Cypher if the editor shows it).
+. Add another card with a different prompt — try "Top 10 rated movies" or whatever fits your data.
+. Drag a card so the layout is not whatever the AI left by default.
+. Rename the dashboard if the default title is useless to you later.
+
+That is enough for module 1; the next module goes deeper on the model and more cards.
 
 [.quiz]
 == Check your understanding
@@ -97,4 +54,4 @@ include::questions/1-requirements.adoc[leveloffset=+1]
 [.summary]
 == Summary
 
-You loaded the Movies dataset and created your first dashboard with AI. In the next module you will describe the graph model, add more cards with AI and Cypher, and style your movies dashboard.
+You got a first dashboard running with AI and explored the interface. Next module: map the model to questions, then add cards with AI and Cypher and tidy the layout.

--- a/asciidoc/courses/aura-dashboards/modules/1-getting-started/lessons/3-exploring-dashboards/lesson.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/1-getting-started/lessons/3-exploring-dashboards/lesson.adoc
@@ -1,8 +1,8 @@
 = Exploring Dashboards
-:order: 3
+:order: 4
 :type: lesson
 
-In the previous lesson you connected to your instance from the Dashboards UI. You should already have graph data in that instance (see link:/courses/aura-dashboards/1-getting-started/1-what-are-dashboards/#sample-graph-data[Sample graph data^] in the first lesson if you still need to load the Movies recommendations dataset). In this lesson you will learn:
+In the previous lesson you connected to your instance from the Dashboards UI. You should already have graph data in that instance (see link:/courses/aura-dashboards/1-getting-started/2-load-sample-data/#sample-graph-data[Load the Movies recommendations dataset^] if you still need to restore it). In this lesson you will learn:
 
 * How to create your first dashboard with AI
 * How to explore the Dashboards interface
@@ -37,7 +37,7 @@ The **Create with AI** feature is only available in the Neo4j Aura Console, and 
 
 // TODO: Screenshot — Card editor with **Visualization type** and Cypher visible (learner “peek” step).
 
-. If you are not sure what is in the graph, run `CALL db.schema.visualization` in **Query** once. If the instance is empty, load data using link:/courses/aura-dashboards/1-getting-started/1-what-are-dashboards/#sample-graph-data[Sample graph data^] in the first lesson.
+. If you are not sure what is in the graph, run `CALL db.schema.visualization` in **Query** once. If the instance is empty, load data using link:/courses/aura-dashboards/1-getting-started/2-load-sample-data/#sample-graph-data[Load the Movies recommendations dataset^].
 . In **Dashboards**, start **Create with AI**, accept the disclaimer, and generate something concrete — "Average rating by genre" is a solid first prompt for the recommendations data.
 . Click through the cards it made. Peek at **Visualization type** (and Cypher if the editor shows it).
 . Add another card with a different prompt — try "Top 10 rated movies" or whatever fits your data.

--- a/asciidoc/courses/aura-dashboards/modules/1-getting-started/lessons/3-exploring-dashboards/questions/1-requirements.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/1-getting-started/lessons/3-exploring-dashboards/questions/1-requirements.adoc
@@ -11,7 +11,7 @@ You want to build a dashboard that shows movie ratings and genre popularity (for
 [TIP,role=hint]
 .Hint
 ====
-Dashboards read data from your Neo4j instance. Load graph data first — for this course, use the Backup & Restore steps under link:/courses/aura-dashboards/1-getting-started/1-what-are-dashboards/#sample-graph-data[Sample graph data^] in the first lesson, or connect to an instance that already has your graph.
+Dashboards read data from your Neo4j instance. Load graph data first — for this course, use the Backup & Restore steps in link:/courses/aura-dashboards/1-getting-started/2-load-sample-data/#sample-graph-data[Load the Movies recommendations dataset^], or connect to an instance that already has your graph.
 ====
 
 [TIP,role=solution]
@@ -19,5 +19,5 @@ Dashboards read data from your Neo4j instance. Load graph data first — for thi
 ====
 **You need graph data in your Neo4j instance.**
 
-Dashboards query whatever is stored in the instance. For the movie-ratings scenario, download the latest dump file from the link:https://github.com/neo4j-graph-examples/recommendations[neo4j-graph-examples/recommendations^] repository and restore it using Aura's Backup & Restore, or use your own graph if it already models ratings and genres.
+Dashboards query whatever is stored in the instance. For the movie-ratings scenario, follow link:/courses/aura-dashboards/1-getting-started/2-load-sample-data/#sample-graph-data[Load the Movies recommendations dataset^], or use your own graph if it already models ratings and genres.
 ====

--- a/asciidoc/courses/aura-dashboards/modules/1-getting-started/lessons/3-exploring-dashboards/questions/1-requirements.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/1-getting-started/lessons/3-exploring-dashboards/questions/1-requirements.adoc
@@ -1,23 +1,23 @@
 [.question]
 = Requirements for creating dashboards
 
-You want to build a movies dashboard that shows movie ratings and genre popularity. What must you have in place before you can build it?
+You want to build a dashboard that shows movie ratings and genre popularity (for example, using the Movies sample graph). What must you have in place before you can build it?
 
 * [ ] You must upgrade to Business Critical tier
 * [ ] You need a separate instance for each dashboard
-* [x] You need the Movies dataset loaded in your instance
+* [x] You need graph data in your Neo4j instance
 * [ ] You must write Cypher queries before creating any cards
 
 [TIP,role=hint]
 .Hint
 ====
-Dashboards read data from your Neo4j instance. You need data in the instance first. For this course, load the Movies dataset using the Cypher script linked in the lesson.
+Dashboards read data from your Neo4j instance. Load graph data first — for this course, use the Backup & Restore steps under link:/courses/aura-dashboards/1-getting-started/1-what-are-dashboards/#sample-graph-data[Sample graph data^] in the first lesson, or connect to an instance that already has your graph.
 ====
 
 [TIP,role=solution]
 .Solution
 ====
-**You need the Movies dataset loaded in your instance.**
+**You need graph data in your Neo4j instance.**
 
-Dashboards query data in your instance. Load the Movies dataset with the Cypher script linked in the lesson before you create cards.
+Dashboards query whatever is stored in the instance. For the movie-ratings scenario, download the latest dump file from the link:https://github.com/neo4j-graph-examples/recommendations[neo4j-graph-examples/recommendations^] repository and restore it using Aura's Backup & Restore, or use your own graph if it already models ratings and genres.
 ====

--- a/asciidoc/courses/aura-dashboards/modules/1-getting-started/module.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/1-getting-started/module.adoc
@@ -1,14 +1,14 @@
-= Getting started
+= Introduction to Neo4j Dashboards
 :order: 1
 
-This module gets you from zero to a first dashboard: what Neo4j Dashboards are, how to connect from Aura, load the Movies dataset, and create your first dashboard with AI.
 
-In this module you will:
+In this module, you will learn what Neo4j Dashboards are, what you need in the Aura Console (including graph data), how to connect Dashboards to your instance, and how to create your first dashboard with AI.
 
-* Learn what Neo4j Dashboards are and when to use them
+You will:
+
+* Explain what Neo4j Dashboards are and when to use them
+* Confirm prerequisites: an AuraDB instance with graph data and access to Dashboards
 * Open Dashboards in Aura and connect to your instance
-* Load the Movies dataset when you do not already have it
 * Create your first dashboard with AI
 
 link:./1-what-are-dashboards/[Ready? Let's go →, role=btn]
-

--- a/asciidoc/courses/aura-dashboards/modules/1-getting-started/module.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/1-getting-started/module.adoc
@@ -2,12 +2,12 @@
 :order: 1
 
 
-In this module, you will learn what Neo4j Dashboards are, what you need in the Aura Console (including graph data), how to connect Dashboards to your instance, and how to create your first dashboard with AI.
+In this module, you will learn what Neo4j Dashboards are, load the Movies recommendations dataset when your instance is empty, connect Dashboards to your instance, and create your first dashboard with AI.
 
 You will:
 
 * Explain what Neo4j Dashboards are and when to use them
-* Confirm prerequisites: an AuraDB instance with graph data and access to Dashboards
+* Restore the recommendations dump (or confirm your own graph) before you chart it
 * Open Dashboards in Aura and connect to your instance
 * Create your first dashboard with AI
 

--- a/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/lessons/1-describe-data-model/lesson.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/lessons/1-describe-data-model/lesson.adoc
@@ -1,10 +1,12 @@
-= Describe your movie data model
-:type: lesson
+= Describe your data model
 :order: 1
+:type: lesson
 
-Your movies dashboard will query nodes, relationships, and properties. Knowing the model helps you write Cypher and choose the right chart types. In this lesson you will learn:
+Your dashboard queries nodes, relationships, and properties. Knowing the model helps you write Cypher and choose the right chart types. This lesson uses the **Movies** sample graph as a concrete example; when you build on your own data, substitute your labels and relationship types.
 
-* How to describe the Movies graph model (nodes, relationships, properties)
+In this lesson you will learn:
+
+* How to describe a graph model (nodes, relationships, properties), using Movies as the worked example
 * How to map stakeholder questions to the data model
 * How to identify the key entities, relationships, and properties in your graph
 
@@ -18,7 +20,7 @@ To understand your graph data model, consider the following questions:
 * What insights do you want to gain from your data?
 
 
-For example, the following structure can be used to describe the movie project:
+For example, the following structure describes the Movies sample graph used in this course:
 
 * **Node labels**:
 ** Movie: the main entity representing films
@@ -44,13 +46,19 @@ For example, the following structure can be used to describe the movie project:
 
 You can view this graph model structure by running `CALL db.schema.visualization` in the Query tool, which you used in the previous lesson to verify your data:
 
+// TODO: Screenshot — **Query** results panel showing `db.schema.visualization` for the recommendations dataset (alongside or instead of the static diagram below).
+
 image::images/movies-model.png[Movie Graph Model,width=600,align=center]
 
-== Analyzing movies project structure
+== Match the picture to your graph
 
-**Challenge**:
+Run `CALL db.schema.visualization` in **Query**. Does it line up with the bullets above? If you brought your own data, jot down three labels you actually care about on a dashboard—ignore the Movies diagram if it does not apply.
 
-Using the movie dataset in your instance, analyze stakeholder requirements and map them to the data model components to design a dashboard for a streaming service executive:
+== Analyzing the worked example
+
+**Stakeholder drill**
+
+Using the Movies graph in your instance (or your own data with a similar stakeholder brief), work through requirements for a streaming executive dashboard:
 
 === Step 1: Identify stakeholders and their goals
 
@@ -99,6 +107,8 @@ When you add cards in the next lesson, you can run this natural language prompt 
 
 Click on *Generate* and choose the preferred visualization type to display the results, such as a pie chart or bar chart:
 
+// TODO: Screenshot — Same workflow as video: natural-language card with **Generate** and visualization picker (optional still).
+
 video::https://cdn.graphacademy.neo4j.com/courses/aura-dashboards-videos/directors-with-highest-movie-ratings.mp4["Directors with Highest Movie Ratings",role="cdn", width=100%]
 
 [NOTE]
@@ -119,6 +129,6 @@ include::questions/1-structure.adoc[leveloffset=+1]
 [.summary]
 == Summary
 
-In this lesson you learned how to describe the graph model and map stakeholder questions to nodes, relationships, and properties.
+You tied stakeholder questions to labels, relationships, and properties—Movies is the example, but the same drill applies to whatever you loaded.
 
-In the next lesson you will add more cards and a filter to the dashboard you created in the previous module.
+Next: more cards with AI and Cypher, plus a filter on the dashboard you already have.

--- a/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/lessons/1-describe-data-model/lesson.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/lessons/1-describe-data-model/lesson.adoc
@@ -2,49 +2,27 @@
 :order: 1
 :type: lesson
 
-Your dashboard queries nodes, relationships, and properties. Knowing the model helps you write Cypher and choose the right chart types. This lesson uses the **Movies** sample graph as a concrete example; when you build on your own data, substitute your labels and relationship types.
+Your dashboard queries nodes, relationships, and properties. **This lesson focuses on one task:** name the labels, relationships, and properties you need so your cards ask answerable questions. The **Movies** sample graph is the example; on your own data, substitute your labels and types.
 
 In this lesson you will learn:
 
-* How to describe a graph model (nodes, relationships, properties), using Movies as the worked example
-* How to map stakeholder questions to the data model
-* How to identify the key entities, relationships, and properties in your graph
+* How to describe a graph model (nodes, relationships, properties) for dashboard work
 
 == Understanding requirements
 
+Ask:
 
-To understand your graph data model, consider the following questions:
+* What are the main node labels and relationship types?
+* What properties do nodes and relationships carry? (For example, ratings live on `RATED` in the recommendations graph.)
+* What question should a card answer for your audience?
 
-* What are the main node labels and relationship types in your data?
-* What properties do nodes and relationships have? For example, movies have a title and release year; ratings have a score.
-* What insights do you want to gain from your data?
+The Movies sample used in this course:
 
+* **Labels:** `Movie`, `Person` (with `Actor` / `Director`), `Genre`, `User`
+* **Types:** `ACTED_IN`, `DIRECTED`, `RATED`, `IN_GENRE`
+* **Properties:** vary by label — `title`, `year`, `imdbRating` on `Movie`; `rating` on `RATED`; and so on.
 
-For example, the following structure describes the Movies sample graph used in this course:
-
-* **Node labels**:
-** Movie: the main entity representing films
-** Actor: people who perform in movies
-** Director: people who direct movies
-** Genre: categories that movies belong to
-** User: people who rate and review movies
-
-
-
-* **Relationship types**:
-** ACTED_IN: connects Actor or Person to Movie
-** DIRECTED: connects Director or Person to Movie
-** RATED: connects User to Movie
-** IN_GENRE: connects Movie to Genre
-
-
-* **Properties**:
-** Movie: title, release_year, genre
-** Actor: name, birthdate
-** Director: name, birthdate
-
-
-You can view this graph model structure by running `CALL db.schema.visualization` in the Query tool, which you used in the previous lesson to verify your data:
+Run `CALL db.schema.visualization` in **Query** and compare to the diagram.
 
 // TODO: Screenshot — **Query** results panel showing `db.schema.visualization` for the recommendations dataset (alongside or instead of the static diagram below).
 
@@ -52,46 +30,15 @@ image::images/movies-model.png[Movie Graph Model,width=600,align=center]
 
 == Match the picture to your graph
 
-Run `CALL db.schema.visualization` in **Query**. Does it line up with the bullets above? If you brought your own data, jot down three labels you actually care about on a dashboard—ignore the Movies diagram if it does not apply.
+Does your `db.schema.visualization` output line up with what you expect? If you use your own graph, write down three labels and two relationship types you will actually chart—ignore the Movies diagram if it does not apply.
 
-== Analyzing the worked example
+== From questions to queries
 
-**Stakeholder drill**
+For a streaming-style brief, stakeholders often care about genre mix, top-rated titles, and who rated what. Those map to paths like `(User)-[:RATED]->(Movie)-[:IN_GENRE]->(Genre)` and director paths through `DIRECTED`. You do not need perfect requirements in one pass; you need enough clarity to pick labels for your next cards.
 
-Using the Movies graph in your instance (or your own data with a similar stakeholder brief), work through requirements for a streaming executive dashboard:
-
-=== Step 1: Identify stakeholders and their goals
-
-Ask questions to understand the stakeholders and their goals. For example:
-
-* Who is the audience for the dashboard?
-* What are the key metrics they want to track?
-
-Consider the following use case - the stakeholders are streaming service executives, content acquisition team and marketing department, who want to track user engagement and content performance metrics, such as:
-
-* Genre trends over time.
-* Top-rated movies and actors.
-* Identify popular content for acquisition.
-
-
-=== Step 2: Map requirements to data model components
-
-Based on the stakeholders' goals, map the requirements to the data model components, by asking more specific questions:
-
-* **What are the most popular genres?**
-** Data needed: Movie nodes with genre property, and RATED relationships to User nodes.
-
-* **Can the number of movies in each genre be counted?**
-** Data needed: Movie nodes with genre property.
-
-* **Optional:** Can a query pattern be defined to find top 10 rated movies per user?
-
-In this scenario, you would need to query Movie nodes that are rated by each User node and find the top 10 rated movies for each user.
-
-Using the dashboard you created in the Exploring Dashboards lesson, run this Cypher query in the dashboard's card editor to get the results:
+**Try:** In a card you already built in link:/courses/aura-dashboards/1-getting-started/3-exploring-dashboards/[Exploring Dashboards^], run this in the card editor to sanity-check ratings data:
 
 [source,cypher]
-.What are top 10 movies and users that have rated those movies?
 ----
 MATCH (u:User)-[r:RATED]->(m:Movie)
 RETURN m.title AS movie, u.name AS user, r.rating AS rating
@@ -99,25 +46,14 @@ ORDER BY r.rating DESC
 LIMIT 10
 ----
 
-* **Which directors have the highest average movie ratings?**
-** Data needed: Director nodes, DIRECTED relationships to Movie nodes, and RATED relationships.
-
-When you add cards in the next lesson, you can run this natural language prompt to get the results:
-'Which directors have the highest average movie ratings?'
-
-Click on *Generate* and choose the preferred visualization type to display the results, such as a pie chart or bar chart:
-
-// TODO: Screenshot — Same workflow as video: natural-language card with **Generate** and visualization picker (optional still).
-
-video::https://cdn.graphacademy.neo4j.com/courses/aura-dashboards-videos/directors-with-highest-movie-ratings.mp4["Directors with Highest Movie Ratings",role="cdn", width=100%]
+When you need a chart you have not typed yet, natural language can help—see `Which directors have the highest average movie ratings?` in the next lesson with **Generate**.
 
 [NOTE]
 .Best practices for dashboard design
 ====
-* Analyze your data model before building dashboards
-* Understand your stakeholders' goals and requirements
-* Choose relevant metrics that align with business objectives
-* Be specific about the node and relationship labels
+* Analyze your data model before adding many cards
+* Tie metrics to stakeholder goals
+* Be specific about labels and relationship types in prompts and Cypher
 ====
 
 
@@ -129,6 +65,4 @@ include::questions/1-structure.adoc[leveloffset=+1]
 [.summary]
 == Summary
 
-You tied stakeholder questions to labels, relationships, and properties—Movies is the example, but the same drill applies to whatever you loaded.
-
-Next: more cards with AI and Cypher, plus a filter on the dashboard you already have.
+You outlined a model for dashboard questions: labels, relationships, and a sample query path. Next: add cards with AI and Cypher, and a filter.

--- a/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/lessons/1-describe-data-model/questions/1-structure.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/lessons/1-describe-data-model/questions/1-structure.adoc
@@ -1,5 +1,5 @@
 [.question]
-= Understanding your movie data model structure
+= Understanding your data model structure
 
 You want to visualize how actors are connected to movies in the Movies graph. Which parts of the graph data model do you use to build that visualization?
 

--- a/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/lessons/2-build-with-ai/lesson.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/lessons/2-build-with-ai/lesson.adoc
@@ -2,63 +2,33 @@
 :order: 2
 :type: lesson
 
-In the previous lesson you described the graph model and mapped stakeholder questions to the data (Movies examples). Use the dashboard you created in link:/courses/aura-dashboards/1-getting-started/3-exploring-dashboards/[Exploring Dashboards^]. If you have not connected data or created a dashboard yet, complete that lesson first.
+In the previous lesson you described the graph model for dashboard questions. Use the dashboard from link:/courses/aura-dashboards/1-getting-started/3-exploring-dashboards/[Exploring Dashboards^] if you have one; otherwise finish that lesson first.
 
-In this lesson you will learn:
+**Topic:** add cards with **Create with AI** and **Cypher**, then wire a **filter** to a query parameter.
 
-* How to add cards to your existing dashboard using AI prompts
-* How to add a card with a Cypher query for precise control
-* How to edit cards and add a filter so viewers can change what is displayed
+Before adding cards, confirm graph data—link:/courses/aura-dashboards/1-getting-started/2-load-sample-data/#sample-graph-data[Load the Movies recommendations dataset^] if your instance is empty.
 
-== Open your dashboard and add a card
+== AI-generated cards
 
-Open your dashboard from the **Dashboards** menu. You will add new cards and a filter to it.
+Open **Dashboards**, open your dashboard, and use **Create with AI** or **Add a card** with natural language. Name node labels and relationship types clearly in the prompt.
 
 image::images/connect-from-dashboards.png[dashboard_connect,width=500,align=center]
 
-Before adding cards, make sure your instance contains graph data. If you are following the Movies track and have not loaded the sample yet, go back to link:/courses/aura-dashboards/1-getting-started/1-what-are-dashboards/#sample-graph-data[Sample graph data^] in the first lesson and restore the recommendations dataset. If you use your own graph, confirm your schema in the Query tool and adapt the examples.
-
-Go to the **Dashboards** tool and click **Create with AI** to begin.
-
-Enter a description of the insights you want to visualize. For example, you can enter a description like "Visualize actor relationships in movies." or simply "Actor relationships":
-
 image::images/create-with-ai-prompt.png[create_with_ai_prompt,width=600,align=center]
-
-[TIP]
-.Be specific
-====
-Be specific about the node labels and relationship types to ensure accurate results.
-====
-
-Create a new AI generated dashboard by clicking the "Generate with AI" button, which will prompt you to enter a description of the insights you want to visualize. The AI will then generate a dashboard based on your description:
 
 video::https://cdn.graphacademy.neo4j.com/courses/aura-dashboards-videos/create-dashboard-with-AI.mp4["Generate Dashboard with AI",role="cdn", width=100%]
 
 // TODO: Screenshot — AI-generated dashboard canvas after **Generate** (this sentence currently has no figure).
 
-You should have a dashboard that looks similar to this:
-
-== Adding more cards
-
-Dashboard cards are individual components that display specific data visualizations.
-
-Click **Add a card** to create your next visualization:
+Click **Add a card** for another visualization; use natural language in the card editor when you want the tool to draft Cypher.
 
 image::images/create-natural-leanguage-card.png[dashboard_editor,width=600,align=center]
 
-You can create cards using AI prompts or Cypher queries. To create a card with AI, use the natural language feature in the card editor:
-
 video::https://cdn.graphacademy.neo4j.com/courses/aura-fundamentals/new-card-ai.mp4["Create New Card with AI",role="cdn", width=100%]
 
-== Adding a card with Cypher
+== Cypher-driven graph card
 
-For precise control over the result, add a card that runs a Cypher query. Click **Add a card**, then in the card editor:
-
-* Change the card title from "New card" to something descriptive like "Actor Overview"
-* Select **Graph** from the visualization type dropdown
-* Paste your Cypher query into the Query field
-
-For example, create a card that shows which movies Tom Hanks has acted in:
+Add a card, set **Visualization type** to **Graph**, and paste Cypher that returns paths you care about:
 
 [source,cypher]
 ----
@@ -69,36 +39,19 @@ RETURN p,r,m
 
 video::https://cdn.graphacademy.neo4j.com/courses/aura-dashboards-videos/first-card-cypher-tom-hanks.mp4["First Card with Cypher - Tom Hanks",role="cdn", width=100%]
 
-Your dashboard will display a graph visualization showing Tom Hanks and his movie connections.
+Use the **six-dot** handle on a card to drag it on the canvas.
 
-[TIP]
-.Repositioning cards
-====
-Move cards by dragging them using the six-dot handle that appears when you hover over a card.
-====
+== Edit and save
 
-== Editing a card
+Open the card menu → **Edit card**, change title, query, or visualization, then **Save changes**.
 
-Change a card by clicking the three-dot menu on the card and selecting **Edit card**.
+== Add a filter
 
-video::https://cdn.graphacademy.neo4j.com/courses/aura-fundamentals/edit-card.mp4["Edit Card",role="cdn", width=100%]
-
-
-Make the changes you want, then click **Save changes** to update the card.
-
-video::https://cdn.graphacademy.neo4j.com/courses/aura-fundamentals/save-card.mp4["Save Card",role="cdn", width=100%]
-
-== Adding a filter
-
-Filters allow users to dynamically change what data is displayed without modifying queries. The **parameters** drawer (`{}` in the dashboard editor) lists named parameters you can use in Cypher as `$parameter_name`. You can add a filter and link it to a parameter automatically, or define parameters first and then link a filter—see link:https://neo4j.com/docs/aura/dashboards/parameters-and-filters/[Filters and parameters^] in the Neo4j Aura documentation for filter types and the full workflow.
-
-To add a filter to your dashboard, go to the dashboard view and select **Add filter**:
+Use the **parameters** drawer (`{}`) to define `$parameter_name` values and link link:https://neo4j.com/docs/aura/dashboards/parameters-and-filters/[filters^] to them.
 
 image::images/04_dashboard_tool_filter.jpg[dashboard_filter,width=300,align=center]
 
-For example, create a "Person selection" filter that will control which actor's data is displayed.
-
-Now update your Actor Overview card query to use the filter parameter:
+Point your Actor card at the parameter:
 
 [source,cypher]
 ----
@@ -107,37 +60,14 @@ WHERE p.name = $person_name
 RETURN p,r,m
 ----
 
-Save your changes and test the filter:
-
 image::images/04_dashboard_tool_selection.jpg[dashboard_selection,width=500,align=center]
-
-Your dashboard now responds dynamically to filter selections:
 
 image::images/04_dashboard_tool_result.jpg[dashboard_result,width=500,align=center]
 
+== Checklist before the quiz
 
-== Try it on your dashboard before the quiz
-
-Back in **Dashboards**, on the dashboard you have been using:
-
-. Add a fresh card with **natural language**—anything that makes sense for your graph.
-. Add a **Cypher** card: the Tom Hanks pattern from this lesson, or your own `MATCH` if the labels differ.
-. Wire **Add filter** to whatever parameter you set up (`$person_name` or your rename) and flip the value a couple of times so you see the graph change.
-. Edit a card title, save, and make sure the canvas updates.
-. Drag a card with the **six-dot** handle so nothing sits awkwardly on the grid.
-
-
-== Where dashboards fit in your workflow
-
-The dashboard tool enables:
-
-* Quick data exploration and validation
-* Creating presentations
-* Building operational monitoring dashboards
-* Prototyping before investing in custom applications
-
-
-
+. One **natural language** card and one **Cypher** graph card on the same dashboard
+. **Filter** bound to `$person_name` (or your name) with the graph updating when you change it
 
 
 [.quiz]
@@ -148,10 +78,10 @@ include::questions/1-dashboards-canvas.adoc[leveloffset=+1]
 [.summary]
 == Summary
 
-You added cards with AI and Cypher, edited them, and hooked up a filter so viewers can switch context without rewriting queries.
+You added cards with AI and Cypher, edited them, and connected a filter to a parameter.
 
 In the next lesson, you will learn how to:
 
 * Organize dashboard structure and create dashboard pages
 * Customize card styling
-* Visualize aggregated metrics
+* Choose visualization types for metrics

--- a/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/lessons/2-build-with-ai/lesson.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/lessons/2-build-with-ai/lesson.adoc
@@ -1,8 +1,8 @@
 = Add cards and filters
-:type: lesson
 :order: 2
+:type: lesson
 
-In the previous lesson you described the Movies graph model and mapped stakeholder questions to the data. Use the dashboard you created in link:/courses/aura-dashboards/1-getting-started/3-exploring-dashboards/[Exploring Dashboards^]. If you have not loaded the Movies data or created a dashboard yet, complete that lesson first.
+In the previous lesson you described the graph model and mapped stakeholder questions to the data (Movies examples). Use the dashboard you created in link:/courses/aura-dashboards/1-getting-started/3-exploring-dashboards/[Exploring Dashboards^]. If you have not connected data or created a dashboard yet, complete that lesson first.
 
 In this lesson you will learn:
 
@@ -12,11 +12,11 @@ In this lesson you will learn:
 
 == Open your dashboard and add a card
 
-Open your movies dashboard from the **Dashboards** menu. You will add new cards and a filter to it.
+Open your dashboard from the **Dashboards** menu. You will add new cards and a filter to it.
 
 image::images/connect-from-dashboards.png[dashboard_connect,width=500,align=center]
 
-Before creating your dashboard, make sure your instance contains the sample movie data. If you haven't done that yet, go back to link:/courses/aura-dashboards/1-getting-started/3-exploring-dashboards/[lesson 3 - Exploring Dashboards^] in the Getting Started module and follow the steps to load the data.
+Before adding cards, make sure your instance contains graph data. If you are following the Movies track and have not loaded the sample yet, go back to link:/courses/aura-dashboards/1-getting-started/1-what-are-dashboards/#sample-graph-data[Sample graph data^] in the first lesson and restore the recommendations dataset. If you use your own graph, confirm your schema in the Query tool and adapt the examples.
 
 Go to the **Dashboards** tool and click **Create with AI** to begin.
 
@@ -33,6 +33,8 @@ Be specific about the node labels and relationship types to ensure accurate resu
 Create a new AI generated dashboard by clicking the "Generate with AI" button, which will prompt you to enter a description of the insights you want to visualize. The AI will then generate a dashboard based on your description:
 
 video::https://cdn.graphacademy.neo4j.com/courses/aura-dashboards-videos/create-dashboard-with-AI.mp4["Generate Dashboard with AI",role="cdn", width=100%]
+
+// TODO: Screenshot — AI-generated dashboard canvas after **Generate** (this sentence currently has no figure).
 
 You should have a dashboard that looks similar to this:
 
@@ -88,7 +90,7 @@ video::https://cdn.graphacademy.neo4j.com/courses/aura-fundamentals/save-card.mp
 
 == Adding a filter
 
-Filters allow users to dynamically change what data is displayed without modifying queries.
+Filters allow users to dynamically change what data is displayed without modifying queries. The **parameters** drawer (`{}` in the dashboard editor) lists named parameters you can use in Cypher as `$parameter_name`. You can add a filter and link it to a parameter automatically, or define parameters first and then link a filter—see link:https://neo4j.com/docs/aura/dashboards/parameters-and-filters/[Filters and parameters^] in the Neo4j Aura documentation for filter types and the full workflow.
 
 To add a filter to your dashboard, go to the dashboard view and select **Add filter**:
 
@@ -114,6 +116,16 @@ Your dashboard now responds dynamically to filter selections:
 image::images/04_dashboard_tool_result.jpg[dashboard_result,width=500,align=center]
 
 
+== Try it on your dashboard before the quiz
+
+Back in **Dashboards**, on the dashboard you have been using:
+
+. Add a fresh card with **natural language**—anything that makes sense for your graph.
+. Add a **Cypher** card: the Tom Hanks pattern from this lesson, or your own `MATCH` if the labels differ.
+. Wire **Add filter** to whatever parameter you set up (`$person_name` or your rename) and flip the value a couple of times so you see the graph change.
+. Edit a card title, save, and make sure the canvas updates.
+. Drag a card with the **six-dot** handle so nothing sits awkwardly on the grid.
+
 
 == Where dashboards fit in your workflow
 
@@ -136,7 +148,7 @@ include::questions/1-dashboards-canvas.adoc[leveloffset=+1]
 [.summary]
 == Summary
 
-In this lesson, you learned how to create interactive dashboards, build dashboard cards with natural language AI prompts, and add filters to make your dashboards dynamic and user-friendly.
+You added cards with AI and Cypher, edited them, and hooked up a filter so viewers can switch context without rewriting queries.
 
 In the next lesson, you will learn how to:
 

--- a/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/lessons/2b-cypher-card-challenge/lesson.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/lessons/2b-cypher-card-challenge/lesson.adoc
@@ -1,0 +1,86 @@
+= Add a Cypher card and filter
+:order: 3
+:type: challenge
+
+In this challenge you will pick a question your dashboard does not yet answer, write Cypher for it in the Query tool, add it as a card, and wire a filter so viewers can change a key value without touching the query.
+
+== Step 1: Pick a question
+
+Choose a question that makes sense for your graph. For the Movies recommendations dataset, try one of these:
+
+* [copy]#Which actors have appeared in more than $min_movies movies?#
+* [copy]#Which movies has $actor_name appeared in, and what is the average rating?#
+* [copy]#Which users have rated more than $min_ratings movies, and what genres do they prefer?#
+
+If you brought your own data, adapt the question to your labels and relationships.
+
+== Step 2: Test your Cypher in the Query tool
+
+Open **Query** in the Aura Console and test your Cypher against the connected instance before adding it to a card. This saves you from debugging inside the card editor.
+
+For the actor filmography question, a starting query looks like this:
+
+[source,cypher]
+----
+MATCH (p:Person:Actor)-[:ACTED_IN]->(m:Movie)
+WHERE p.name = $actor_name
+RETURN m.title AS title,
+       m.year AS year,
+       m.imdbRating AS imdb_rating
+ORDER BY m.year DESC;
+----
+
+Replace `$actor_name` with a hardcoded string like `'Tom Hanks'` to verify the query returns results, then switch back to the `$actor_name` parameter form before pasting into the card editor.
+
+For the genre preferences question, alias the `RATED` relationship so you can access `r.rating`:
+
+[source,cypher]
+----
+MATCH (u:User)-[r:RATED]->(m:Movie)-[:IN_GENRE]->(g:Genre)
+WHERE u.name = $user_name
+RETURN g.name                   AS genre,
+       count(m)                 AS movie_count,
+       round(avg(r.rating), 1)  AS avg_rating
+ORDER BY movie_count DESC;
+----
+
+[TIP]
+.Rating on the relationship
+====
+The `rating` property lives on the `RATED` relationship, not on the `Movie` node. Always alias the relationship (`-[r:RATED]->`) so you can access `r.rating` in `RETURN` and `WHERE`.
+====
+
+== Step 3: Add the card to your dashboard
+
+// TODO: Screenshot — Card editor: **Table** visualization, Cypher with `$parameter`, **Run** / **Save changes**.
+
+Open your dashboard in **Dashboards** and click **Add a card**.
+
+In the card editor:
+
+. Set a descriptive **title** (for example, "Actor filmography" or "Genre preferences by user").
+. Set **Visualization type** to **Table** — this is a good default for parameterized queries because you can see all returned columns clearly.
+. Paste your Cypher query (with the `$parameter_name` placeholder, not the hardcoded test value).
+. Click **Run** inside the editor to confirm it returns data with the default parameter value.
+. Click **Save changes**.
+
+== Step 4: Wire a filter
+
+// TODO: Screenshot — Parameters drawer (`{}`) with a parameter defined, and **Add filter** linked to that parameter (filter type **Free text** or **Dropdown**).
+
+Parameters let viewers change a key value without editing the query. Open the **parameters drawer** (`{}` in the dashboard editor toolbar) and add a new parameter that matches the placeholder in your Cypher — for example, `actor_name` or `user_name`.
+
+Then click **Add filter** and link it to that parameter. Set the filter type to **Free text** (or **Dropdown** if you want to restrict the values) and give it a label the viewer will understand.
+
+Test the filter: change the value and confirm the card updates.
+
+For reference, the link:https://neo4j.com/docs/aura/dashboards/parameters-and-filters/[Filters and parameters documentation^] covers filter types and the full parameter workflow.
+
+read::Mark as completed[]
+
+[.summary]
+== Summary
+
+You tested Cypher in the Query tool, added a card with a parameterized query, and connected a filter so viewers can change the key value without rewriting the query.
+
+Next: pages, styling, and exporting the dashboard JSON.

--- a/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/lessons/3-first-card/lesson.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/lessons/3-first-card/lesson.adoc
@@ -1,12 +1,13 @@
 = Organize your dashboard structure
+:order: 4
 :type: lesson
-:order: 3
 
 In the previous lesson you added cards with AI and Cypher and a filter. Use that dashboard here. If you do not have a dashboard with cards yet, complete the previous lesson first.
 
 In this lesson you will learn:
 
 * How to add a new dashboard page and name it
+* How to import, export, or copy a dashboard JSON definition
 * How to customize how cards look using the Results overview
 
 Before you start, make sure you have completed the previous lesson and have a dashboard with at least one card.
@@ -36,6 +37,15 @@ Give the page a clear name, such as "Stakeholders view", and click **Create**. Y
 
 video::https://cdn.graphacademy.neo4j.com/courses/aura-dashboards-videos/rename-dashboard-page.mp4["Rename Dashboard Page",role="cdn", width=100%]
 
+== Import and export dashboard definitions
+
+// TODO: Screenshot — **Import** dashboard JSON dialog (browse / paste / source options called out in docs).
+// TODO: Screenshot — Dashboard **tile** `...` menu with **Export file…** and **Copy to clipboard**.
+
+When you **create** a dashboard, you can **Import** a JSON definition: browse for a file, paste JSON, import from NeoDash commercial or NeoDash Labs, or in some setups select JSON stored in the database. The import dialog shows a summary of pages, cards, parameters, and filters migrated or converted. See link:https://neo4j.com/docs/aura/dashboards/import/[Import and export^] for supported NeoDash report types and limitations.
+
+From the **Dashboards** list (dashboard tiles, not inside the editor), open the more menu (`...`) on a dashboard tile. You can **Export file…** to download JSON, or **Copy to clipboard** to copy the same definition. Use these options to back up a layout, move a dashboard between instances, or share JSON with a teammate. The export file name format is `{dashboard title}_{YYYY-MM-DD}.json`. See link:https://neo4j.com/docs/aura/dashboards/managing-dashboards/[Managing dashboards^] for editing, pages, and deleting dashboards.
+
 == Styling cards
 
 Change how graph results look by opening the **Results overview** for a card and adjusting colors, sizes, and captions for node labels and relationship types.
@@ -47,6 +57,8 @@ image::images/02_query_tool_styling.jpg[querytool_styling,width=600,align=center
 In the previous lesson you created cards using AI. For more control over data visualization, create cards using Cypher queries directly.
 
 From your dashboard, click **Add a card** to open the card editor.
+
+// TODO: Screenshot — **Add a card** / card editor empty state with Query field (if not covered elsewhere).
 
 Use the card editor to define the card properties and paste your Cypher query into the Query field.
 
@@ -61,6 +73,12 @@ RETURN p,r,m
 
 video::https://cdn.graphacademy.neo4j.com/courses/aura-dashboards-videos/first-card-cypher-tom-hanks.mp4["First Card with Cypher - Tom Hanks",role="cdn", width=100%]
 
+== Pages, styling, and JSON—try it
+
+. Add another **page** (tab). Name it for whoever would read it—``Marketing``, ``Exec``, or something honest for your case.
+. On a **Graph** card, open **Results overview** and tweak **color** or **caption** for one label so the story reads clearer.
+. From the **Dashboards** tile list, open ``…`` on this dashboard → **Copy to clipboard**, paste once into an editor if you want to see the JSON shape—you can delete it after.
+. If you like files on disk, hit **Export file…** and check the downloaded ``.json`` name.
 
 
 [.quiz]
@@ -73,6 +91,6 @@ include::questions/1-pages-and-cypher.adoc[leveloffset=+1]
 [.summary]
 == Summary
 
-In this lesson you added a dashboard page, renamed it, and styled cards using the Results overview.
+You split work across pages, nudged styling in **Results overview**, and saw how dashboard definitions move as JSON.
 
-In the next lesson you will add aggregations such as counts and averages and choose chart types for ratings, genres, and actors.
+Next: counts, averages, and picking chart types that fit the shape of each query.

--- a/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/lessons/3-first-card/lesson.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/lessons/3-first-card/lesson.adoc
@@ -93,4 +93,4 @@ include::questions/1-pages-and-cypher.adoc[leveloffset=+1]
 
 You split work across pages, nudged styling in **Results overview**, and saw how dashboard definitions move as JSON.
 
-Next: counts, averages, and picking chart types that fit the shape of each query.
+Next: match **Visualization type** to your query result shape.

--- a/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/lessons/4-visualise-aggregations/lesson.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/lessons/4-visualise-aggregations/lesson.adoc
@@ -1,45 +1,36 @@
-= Add aggregations and chart types
+= Match chart types to your query
 :order: 5
 :type: lesson
 
-In the previous lesson you organized pages and styled graph cards. In this lesson you will learn:
+In the previous lesson you organized pages and styled graph cards. **This lesson has one focus:** choose a **Visualization type** so the shape of the chart matches the shape of your query result—rows, categories, a trend, one number, or prose.
 
-* How to add cards that show counts, averages, and distributions
-* How to run Cypher queries that aggregate data
-* How to choose the right visualization type for each card
+In this lesson you will learn:
 
-Keep **Dashboards** open—most of this lesson is copying queries, changing **Visualization type**, and saving.
+* How to pick a visualization type for counts, averages, and distributions
 
-== Visualization types
+Keep **Dashboards** open—most steps are: paste the query, set **Visualization type**, then **Save**.
 
-In the card editor, use the **Visualization type** dropdown to match the chart to your data: relationships, rows, trends over time, or a single number.
+== The Visualization type dropdown
 
-* **Graph** - Shows relationships between nodes
-* **Table** - Displays detailed data in a structured format
-* **Line Chart** - Tracks trends over time
-* **Bar Chart** - Compares quantities across categories
-* **Pie Chart** - Displays proportions of a whole
-* **Single Value** - Highlights a key metric
-* **Text** - Adds descriptive information or context
+In the card editor, use **Visualization type** to match the chart to your data. See link:https://neo4j.com/docs/aura/dashboards/[Neo4j Aura Dashboards documentation^] for the full list and settings.
 
-From the card editor, select the dropdown menu under **Visualization type** to choose the most appropriate visualization for your data:
-
+| Use | When the query returns |
+|----|----|
+| **Graph** | Nodes and relationships |
+| **Table** | Rows and columns |
+| **Bar chart** | Categories and one numeric value per category |
+| **Line chart** | An ordered dimension (for example year) and a value |
+| **Pie chart** | Parts of a whole share |
+| **Single value** | One row, one numeric column |
+| **Text** | Markdown for context |
 
 image::images/change-card-type.png[Change card type dialog,width=600,align=center]
 
+== Three patterns to try
 
-=== Graph card
+=== Table: top ratings
 
-Use a **Graph** card when your query returns nodes and relationships. For example, actors and the movies they acted in. You can ask the AI for a graph card or write Cypher that returns nodes and relationships.
-
-Try a graph card that shows actors and movies:
-
-image::images/ai-generated-graph.png[Graph card example,width=600,align=center]
-
-=== Table card
-
-Use a **Table** when you have rows and columns, such as movie, user, and rating. Add a card, paste the query below into the card editor, and run it.
-[source,cypher ]
+[source,cypher]
 ----
 MATCH (u:User)-[r:RATED]->(m:Movie)
 RETURN m.title AS movie, u.name AS user, r.rating AS rating
@@ -47,174 +38,27 @@ ORDER BY r.rating DESC
 LIMIT 10
 ----
 
+Set **Visualization type** to **Table**.
+
 image::images/table-top10-ratings-per-user-cypher.png[Table card example,width=600,align=center]
 
+=== Bar chart: average IMDb by genre
 
-=== Bar Chart card
-
-Use a **Bar Chart** when you have categories, such as genre or country, and a value to compare, such as count or average rating. This matches the chart you saw in lesson 1: average rating by genre.
-
-Add a card and run this query, then set the visualization type to **Bar Chart**:
-[source,cypher ]
+[source,cypher]
 ----
 MATCH (m:Movie)-[:IN_GENRE]->(g:Genre)
-WHERE m.rating IS NOT NULL
-RETURN g.name AS genre, round(avg(toFloat(m.rating)), 2) AS avgRating
-ORDER BY avgRating DESC
+WHERE m.imdbRating IS NOT NULL
+RETURN g.name AS genre, round(avg(m.imdbRating), 2) AS avg_imdb
+ORDER BY avg_imdb DESC
 ----
 
-Your card should look like the average rating by genre chart from lesson 1:
+Set **Visualization type** to **Bar chart**.
 
 image::images/average-rating-by-genre.png[Average rating by genre chart,width=600,align=center]
 
-*Challenge:* Create another bar chart that shows the number of movies per genre, or movies directed per country.
+=== Single value and text
 
-=== Line chart card
-
-Use a **Line Chart** when you have an ordered dimension (for example year) and a value to plot. It works well for trends over time.
-
-Add a card and run this query, then set the visualization type to **Line Chart**:
-[source,cypher ]
-----
-MATCH (m:Movie)
-WHERE m.release_year IS NOT NULL
-WITH m.release_year AS year, count(m) AS movieCount
-RETURN year, movieCount
-ORDER BY year
-----
-
-Your card will show movie count over time. Use a line chart whenever you want to show how a value changes across an ordered dimension (years, months, etc.).
-
-=== Pie Chart card
-
-// TODO: Screenshot — **Pie chart** card result (directors or genres) to pair with the video below.
-
-Use a **Pie Chart** when you want to show how parts make up a whole, such as share of movies per genre or top directors by average rating.
-
-You can ask the AI: "Create a pie chart showing directors with the highest average movie ratings." Or add a card and run this Cypher:
-
-[source,cypher ]
-----
-/* Which directors have the highest average movie ratings? */
-
-MATCH (d:Director)-[r:DIRECTED]->(m:Movie)<-[r2:RATED]-(u:User)
-WITH d, avg(r2.rating) AS averageRating
-ORDER BY averageRating DESC
-RETURN d.name AS directorName, averageRating
-LIMIT 10
-----
-
-video::https://cdn.graphacademy.neo4j.com/courses/aura-dashboards-videos/directors-with-highest-movie-ratings.mp4["Directors with Highest Movie Ratings",role="cdn", width=100%]
-
-=== Single Value card
-
-Use a **Single Value** card when your query returns one row and one number. For example, total count of movies.
-
-Add a card and run this query:
-
-[source,cypher ]
-----
-MATCH (n)
-RETURN COUNT(n) as Total
-----
-
-Your card will show a single number. If your value is different, that is fine; it depends on what is in your instance.
-
-image::images/single-card.png[Single Value card example,width=600,align=center]
-
-=== Text card
-
-Use a **Text** card to add titles, descriptions, or context so anyone viewing the dashboard knows what they're looking at. You can write plain text or use markdown.
-
-Try a text card for a movie, such as __The Matrix__. Add a card, choose **Text** as the visualization type, and paste this markdown:
-
-[source,markdown]
-----
-# The Matrix (1999)
-
-## Overview
-A computer hacker learns from mysterious rebels about the true nature of his reality and his role in the war against its controllers.
-
-## Details
-
-**Director:** The Wachowskis
-**Released:** March 31, 1999
-**Runtime:** 136 minutes
-**Rating:** R
-
-### Genre
-
-- Science Fiction
-- Action
-- Cyberpunk
-
-### Cast
-
-- **Keanu Reeves** as Neo
-- **Laurence Fishburne** as Morpheus
-- **Carrie-Anne Moss** as Trinity
-- **Hugo Weaving** as Agent Smith
-
-## Box Office & Reception
-
-**Budget:** $63 million
-**Box Office:** $467.2 million worldwide
-**IMDb Rating:** 8.7/10
-**Rotten Tomatoes:** 88% (Critics), 85% (Audience)
-
-## Awards
-
-- 🏆 4 Academy Awards (Visual Effects, Sound, Film Editing, Sound Effects Editing)
-- 🏆 2 BAFTA Awards
-
-## Key Relationships in Graph
-
-```
-(The Matrix)-[:DIRECTED_BY]->(The Wachowskis)
-(Keanu Reeves)-[:ACTED_IN {role: "Neo"}]->(The Matrix)
-(The Matrix)-[:GENRE]->(Science Fiction)
-```
-
-## Tagline
-
-*"Free your mind."*
-
----
-
-**Last Updated:** 2025-11-11
-**Data Source:** Neo4j Movies Database
-----
-
-
-The card editor renders the markdown. You can scroll to see the full content and use the menu to edit or switch back to raw markdown.
-
-image::images/text-card-matrix-part1.png[text card example part 1,width=600,align=center]
-
-On the dashboard, the text card appears as a short overview:
-
-image::images/text-card-matrix-part2.png[text card example part 2,width=600,align=center]
-
-Add a **Text** card (or two) in plain language: what should a stakeholder take away from the numbers on this page?
-
-=== Putting it together
-
-When you build your own cards, choose the type that fits the data: use bar or pie for category counts, line for trends over time, table for row-by-row detail, and text to explain what the numbers mean.
-
-== Marketing-style page (your spin)
-
-Spin up a **new page** (or a new dashboard) called something like *Marketing*—the label is yours.
-
-. **Movies per genre**—pick bar, pie, or table; any of the three can work depending on how busy the chart looks with your data.
-. **Average rating by genre**—borrow the bar pattern from here or from lesson 1.
-. **Directors by average rating**—pie or bar; pick what reads faster for you.
-. Drop in a short **Text** card: what decision would marketing make off this page?
-. If you want feedback, the link:https://community.neo4j.com[community forum^] is a fine place to show a screenshot and ask why someone might pick bar over pie for one of these.
-
-=== Practice with aggregations
-
-If you want more practice with counts and averages, try these queries. Add a separate card for each and choose the visualization type that fits.
-
-* **Count:** How many movies?
+**Count** nodes with a query that returns one number. Example:
 
 [source,cypher]
 ----
@@ -222,48 +66,29 @@ MATCH (m:Movie)
 RETURN count(m) AS total_movies
 ----
 
-* **Average:** Average rating per genre and how many movies.
+Set **Visualization type** to **Single value**.
 
-[source,cypher]
-----
-MATCH (m:Movie)-[:IN_GENRE]->(g:Genre)
-RETURN g.name AS genre,
-    avg(toFloat(m.rating)) AS average_rating,
-    count(m) AS total_movies
-ORDER BY average_rating DESC
-----
+image::images/single-card.png[Single Value card example,width=600,align=center]
 
+For **Text**, choose **Text** and paste short markdown (title, bullets, data source). Use it to explain what the numbers on the page are for.
 
-
-video::https://cdn.graphacademy.neo4j.com/courses/aura-dashboards-videos/first-card-average-rating-by-genre.mp4["First Card - Average Rating by Genre",role="cdn", width=100%]
-
-* **Distribution:** How many ratings at each rating value.
-
-[source,cypher]
-----
-MATCH (m:Movie)
-WHERE m.rating IS NOT NULL
-RETURN m.rating AS rating,
-    count(*) AS count
-ORDER BY rating DESC
-----
-
-[TIP]
-.Same query, different chart
-====
-You can use the same Cypher in more than one card and set a different visualization type, such as bar in one card and pie in another, to compare how each presents the data. Functions like `count()`, `avg()`, and `sum()` are what you need for aggregations.
-====
+image::images/text-card-matrix-part1.png[text card example part 1,width=600,align=center]
 
 == Same query, different chart
 
-Copy the **Count** query from **Practice with aggregations** into **two** cards. Set one to **Single value** and the other to **Table** (or **Bar** if the rows fit). Same `RETURN`, different presentation—that split is the whole skill.
+Copy a simple `RETURN` into **two** cards and set **Visualization type** differently (for example **Single value** vs **Table**). The query is the same; only the presentation changes.
+
+[TIP]
+.Aggregations
+====
+`count()`, `avg()`, and `sum()` are what you need for totals and averages. Pair the aggregated `RETURN` with a chart type that fits: bar for categories, line for ordered dimensions, single value for one metric.
+====
 
 [NOTE]
 .Access and security
 ====
-Dashboard viewers only see data they have permission to access. If a user's role does not allow viewing certain data, that data does not appear in the dashboard for them.
+Dashboard viewers only see data their role allows. If a role cannot read certain nodes, those rows do not appear in the card.
 ====
-
 
 
 [.quiz]
@@ -275,6 +100,6 @@ include::questions/1-purpose.adoc[leveloffset=+1]
 [.summary]
 == Summary
 
-You practiced COUNT/AVG, mixed bar, pie, table, graph, and text, and saw how one query can look different when you change the visualization alone.
+You matched **Visualization type** to query result shape—table, bar, single value, and text—and saw why the same `RETURN` can power more than one card.
 
 Next: who gets to see the dashboard, and how invites work in Aura.

--- a/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/lessons/4-visualise-aggregations/lesson.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/lessons/4-visualise-aggregations/lesson.adoc
@@ -1,12 +1,14 @@
 = Add aggregations and chart types
+:order: 5
 :type: lesson
-:order: 4
 
 In the previous lesson you organized pages and styled graph cards. In this lesson you will learn:
 
 * How to add cards that show counts, averages, and distributions
 * How to run Cypher queries that aggregate data
 * How to choose the right visualization type for each card
+
+Keep **Dashboards** open—most of this lesson is copying queries, changing **Visualization type**, and saving.
 
 == Visualization types
 
@@ -84,6 +86,8 @@ ORDER BY year
 Your card will show movie count over time. Use a line chart whenever you want to show how a value changes across an ordered dimension (years, months, etc.).
 
 === Pie Chart card
+
+// TODO: Screenshot — **Pie chart** card result (directors or genres) to pair with the video below.
 
 Use a **Pie Chart** when you want to show how parts make up a whole, such as share of movies per genre or top directors by average rating.
 
@@ -190,21 +194,21 @@ On the dashboard, the text card appears as a short overview:
 
 image::images/text-card-matrix-part2.png[text card example part 2,width=600,align=center]
 
-*Challenge:* Add one or two more text cards to give context to the charts on your dashboard.
+Add a **Text** card (or two) in plain language: what should a stakeholder take away from the numbers on this page?
 
 === Putting it together
 
 When you build your own cards, choose the type that fits the data: use bar or pie for category counts, line for trends over time, table for row-by-row detail, and text to explain what the numbers mean.
 
-*Hands-on challenge*
+== Marketing-style page (your spin)
 
-Create a dashboard or a new page for a "marketing team" view. Add cards that show:
+Spin up a **new page** (or a new dashboard) called something like *Marketing*—the label is yours.
 
-* Total movies per genre
-* Average rating by genre (like the chart in lesson 1)
-* Top 5 directors by average movie rating
-
-Pick the chart type that fits each one: for example, bar for genre counts and average rating by genre. Add a text card or two to explain what the numbers mean. Share your dashboard with a peer or on the link:https://community.neo4j.com[Neo4j Community forum^] and discuss why you chose each visualization.
+. **Movies per genre**—pick bar, pie, or table; any of the three can work depending on how busy the chart looks with your data.
+. **Average rating by genre**—borrow the bar pattern from here or from lesson 1.
+. **Directors by average rating**—pie or bar; pick what reads faster for you.
+. Drop in a short **Text** card: what decision would marketing make off this page?
+. If you want feedback, the link:https://community.neo4j.com[community forum^] is a fine place to show a screenshot and ask why someone might pick bar over pie for one of these.
 
 === Practice with aggregations
 
@@ -250,6 +254,10 @@ ORDER BY rating DESC
 You can use the same Cypher in more than one card and set a different visualization type, such as bar in one card and pie in another, to compare how each presents the data. Functions like `count()`, `avg()`, and `sum()` are what you need for aggregations.
 ====
 
+== Same query, different chart
+
+Copy the **Count** query from **Practice with aggregations** into **two** cards. Set one to **Single value** and the other to **Table** (or **Bar** if the rows fit). Same `RETURN`, different presentation—that split is the whole skill.
+
 [NOTE]
 .Access and security
 ====
@@ -267,6 +275,6 @@ include::questions/1-purpose.adoc[leveloffset=+1]
 [.summary]
 == Summary
 
-You used aggregations such as COUNT and AVG and chart types such as bar, pie, table, and graph to visualize ratings, genres, and actors on your movies dashboard.
+You practiced COUNT/AVG, mixed bar, pie, table, graph, and text, and saw how one query can look different when you change the visualization alone.
 
-In the next module you will share your dashboard with others.
+Next: who gets to see the dashboard, and how invites work in Aura.

--- a/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/lessons/4b-aggregations-challenge/lesson.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/lessons/4b-aggregations-challenge/lesson.adoc
@@ -1,0 +1,115 @@
+= Build an aggregations page
+:order: 6
+:type: challenge
+
+In this challenge you will build a self-contained metrics page on your dashboard. The page should tell a complete story using at least three chart types, so a viewer can read the numbers and the context without opening a second tab.
+
+== Step 1: Add a new dashboard page
+
+// TODO: Screenshot — Completed metrics page: Single value + bar + line + text cards in one layout (reference layout for learners).
+
+Open your dashboard in **Dashboards** and click **New page**. Name it something that signals the audience or purpose — for example, "Content metrics", "Director stats", or "Genre overview".
+
+== Step 2: Add a Single Value card
+
+Add a card that returns one number. Single Value cards work best as the first thing a viewer sees: the number frames everything else on the page.
+
+[source,cypher]
+.Total movies in the dataset
+----
+MATCH (m:Movie)
+RETURN count(m) AS total_movies;
+----
+
+Set **Visualization type** to **Single value**. You can also try the total number of ratings:
+
+[source,cypher]
+.Total ratings
+----
+MATCH ()-[r:RATED]->()
+RETURN count(r) AS total_ratings;
+----
+
+== Step 3: Add a Bar Chart card
+
+Add a card that compares a metric across categories. Bar charts are the clearest choice when you have 3–15 categories and a single numeric value to compare.
+
+[source,cypher]
+.Average IMDb rating per genre (top 15)
+----
+MATCH (m:Movie)-[:IN_GENRE]->(g:Genre)
+WHERE m.imdbRating IS NOT NULL
+RETURN g.name                        AS genre,
+       round(avg(m.imdbRating), 2)   AS avg_imdb,
+       count(m)                      AS movie_count
+ORDER BY avg_imdb DESC
+LIMIT 15;
+----
+
+Set **Visualization type** to **Bar chart**. If the genre labels overlap on the axis, switch to a **horizontal** bar layout in the card settings.
+
+== Step 4: Add a Line Chart card
+
+Add a card that shows a trend over an ordered dimension. Line charts suit time-series or year-by-year data.
+
+[source,cypher]
+.Movies released per year
+----
+MATCH (m:Movie)
+WHERE m.year IS NOT NULL
+RETURN m.year AS year, count(m) AS releases
+ORDER BY year;
+----
+
+Set **Visualization type** to **Line chart**. The x-axis maps to `year` and the y-axis to `releases`.
+
+For a second angle, you can show average IMDb rating by decade:
+
+[source,cypher]
+.Average IMDb rating by decade
+----
+MATCH (m:Movie)
+WHERE m.year IS NOT NULL AND m.imdbRating IS NOT NULL
+WITH (m.year / 10) * 10 AS decade, m.imdbRating AS rating
+RETURN decade,
+       round(avg(rating), 2) AS avg_imdb,
+       count(*) AS total
+ORDER BY decade;
+----
+
+== Step 5: Add a Text card
+
+Add a **Text** card that explains what this page is for. A viewer who lands on this page without context needs to know what question it answers and what the numbers mean.
+
+Write two or three sentences in plain language. For example:
+
+[source,markdown]
+----
+## Content performance overview
+
+This page summarises movie volume, release trends, and audience ratings across genres.
+
+**Data source:** GraphAcademy Movies recommendations dataset — approximately 9,000 movies and 100,000 ratings.
+----
+
+Set **Visualization type** to **Text**. Put this card at the top-left or top-right of the page so it reads before the numbers.
+
+== Step 6: Arrange the layout
+
+Drag the cards using the six-dot handle on each card so the layout reads top-to-bottom in order of importance:
+
+. Single Value (the headline number)
+. Bar Chart (category comparison)
+. Line Chart (trend over time)
+. Text card (context, either first or last depending on how much explanation you want)
+
+Read the page as a viewer would: does it tell a coherent story without any other instructions?
+
+read::Mark as completed[]
+
+[.summary]
+== Summary
+
+You built a metrics page with a Single Value, Bar Chart, Line Chart, and Text card, and arranged the layout so it reads as a complete story.
+
+The optional next lesson adds geographic cards using the Map visualization.

--- a/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/lessons/5-map-dashboard-challenge/lesson.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/lessons/5-map-dashboard-challenge/lesson.adoc
@@ -3,7 +3,7 @@
 :type: challenge
 :optional: true
 
-Optional add-on after link:../4-visualise-aggregations/[Add aggregations and chart types^]—maps never showed up there.
+Optional add-on after link:../4-visualise-aggregations/[Match chart types to your query^]—maps never showed up there.
 
 Here you plot **where** something lives (users, stores, offices) on a **Map** card, and usually pair it with a table or bar so the map is not floating without context. You will touch **Query** to add or check coordinates, then **Dashboards** to render them.
 
@@ -11,7 +11,7 @@ Use **your own graph** if it already has coordinates or addresses you can turn i
 
 == Before you start
 
-You should already be comfortable adding cards and switching chart types from link:../4-visualise-aggregations/[Add aggregations and chart types^]. Keep **Query** handy if you are stamping coordinates onto nodes, and **Dashboards** open for the Map card itself.
+You should already be comfortable adding cards and switching chart types from link:../4-visualise-aggregations/[Match chart types to your query^]. Keep **Query** handy if you are stamping coordinates onto nodes, and **Dashboards** open for the Map card itself.
 
 Run `CALL db.schema.visualization` once — on the Movies track you should see **`User`**, **`RATED`**, **`Movie`**, **`Genre`**, **`Person`** and the other labels from the recommendations dataset.
 
@@ -48,7 +48,7 @@ You choose the question—for example “where are reviewers concentrated?”, �
 
 == Path B: Movies recommendations dataset
 
-The recommendations dataset does not ship coordinates, but each of its three main node types has a property you can turn into a `Point` with a one-time seed query. Run any one — or all three — depending on the story you want to tell on the map.
+The recommendations dataset does not ship coordinates. **This challenge focuses on one default path:** seed users to metro areas, then map them. Optional seeds for `Person` and `Movie` are in a collapsible section below.
 
 === Seed 1: Users by metro area (fictional)
 
@@ -104,6 +104,10 @@ RETURN u.metro_region             AS metro,
        count(r)                   AS total_ratings
 ORDER BY total_ratings DESC;
 ----
+
+[%collapsible]
+.Optional seeds: Person birth country and Movie production country
+====
 
 === Seed 2: People by birth country
 
@@ -289,6 +293,8 @@ RETURN m.production_country        AS country,
 ORDER BY movie_count DESC
 LIMIT 15;
 ----
+
+====
 
 == Stretch ideas
 

--- a/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/lessons/5-map-dashboard-challenge/lesson.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/lessons/5-map-dashboard-challenge/lesson.adoc
@@ -1,0 +1,306 @@
+= Create a map dashboard
+:order: 7
+:type: challenge
+:optional: true
+
+Optional add-on after link:../4-visualise-aggregations/[Add aggregations and chart types^]—maps never showed up there.
+
+Here you plot **where** something lives (users, stores, offices) on a **Map** card, and usually pair it with a table or bar so the map is not floating without context. You will touch **Query** to add or check coordinates, then **Dashboards** to render them.
+
+Use **your own graph** if it already has coordinates or addresses you can turn into coordinates. If you do not have geographic data yet, use the **Movies recommendations** dataset and one of the seed queries in Path B to stamp coordinates onto nodes.
+
+== Before you start
+
+You should already be comfortable adding cards and switching chart types from link:../4-visualise-aggregations/[Add aggregations and chart types^]. Keep **Query** handy if you are stamping coordinates onto nodes, and **Dashboards** open for the Map card itself.
+
+Run `CALL db.schema.visualization` once — on the Movies track you should see **`User`**, **`RATED`**, **`Movie`**, **`Genre`**, **`Person`** and the other labels from the recommendations dataset.
+
+== What Map cards need
+
+// TODO: Screenshot — **Map** card with points on the map and **Settings** for spatial property.
+// TODO: Screenshot — Same page: **Map** plus one **Bar chart** or **Table** (paired context).
+
+A **Map** visualization plots **nodes** that carry coordinates. Dashboards resolve positions in this order on each node:
+
+. A property of type **`Point`** (WGS 84), or
+. Paired **`latitude`** and **`longitude`** properties, or
+. Paired **`lat`** and **`long`**
+
+See link:https://neo4j.com/docs/aura/dashboards/visualizations/map/[Map visualization^] for settings (map style, which `Point` property to use when a label has more than one).
+
+Use **`point({latitude: <degrees>, longitude: <degrees>})`** in Cypher. Latitudes are -90 to 90; longitudes -180 to 180. Use **decimal degrees**, not degree-minute-second strings.
+
+== Goal
+
+Create a **new dashboard page** (name it however you like) that tells a small **geographic story** about your data:
+
+. At least **one Map** card whose Cypher returns nodes (and relationships, if useful) that include coordinates.
+. At least **one non-map** card on the same page (for example **Bar chart**, **Table**, or **Single value**) that summarizes or ranks the same topic by region, count, or average—so the map is not floating without context.
+
+You choose the question—for example “where are reviewers concentrated?”, “which warehouses sit closest to suppliers?”, or “which offices log the most incidents?”—as long as it fits **your** labels and relationships.
+
+== Path A: Your own dataset
+
+. Inspect your schema in **Query** (`CALL db.schema.visualization` or the database information panel).
+. Decide which nodes represent **places** or **people at a place**, and add or reuse properties so Map can place them (`Point`, or `latitude`/`longitude`, or `lat`/`long`).
+. Write Cypher that returns those nodes (and paths you care about) with **`RETURN` shapes** the Map card can render (see the Map documentation).
+. In Dashboards, add a card → set **Visualization type** to **Map** → paste your query → adjust **Settings** if you must pick a spatial property.
+
+== Path B: Movies recommendations dataset
+
+The recommendations dataset does not ship coordinates, but each of its three main node types has a property you can turn into a `Point` with a one-time seed query. Run any one — or all three — depending on the story you want to tell on the map.
+
+=== Seed 1: Users by metro area (fictional)
+
+Distributes `User` nodes across six US metro areas — not real addresses.
+
+[source,cypher]
+----
+// Fictional survey-style locations — not real user data.
+MATCH (u:User)
+WITH u ORDER BY coalesce(u.name, elementId(u))
+WITH collect(u) AS users
+UNWIND range(0, size(users) - 1) AS idx
+WITH users[idx] AS u, idx
+WITH u,
+  CASE idx % 6
+    WHEN 0 THEN {metro: 'New York',    lat:  40.7128, lon:  -74.0060}
+    WHEN 1 THEN {metro: 'Los Angeles', lat:  34.0522, lon: -118.2437}
+    WHEN 2 THEN {metro: 'Chicago',     lat:  41.8781, lon:  -87.6298}
+    WHEN 3 THEN {metro: 'Houston',     lat:  29.7604, lon:  -95.3698}
+    WHEN 4 THEN {metro: 'Phoenix',     lat:  33.4484, lon: -112.0740}
+    ELSE        {metro: 'Miami',       lat:  25.7617, lon:  -80.1918}
+  END AS geo
+SET u.home_location = point({latitude: geo.lat, longitude: geo.lon}),
+    u.metro_region   = geo.metro;
+----
+
+**Verify:**
+
+[source,cypher]
+----
+MATCH (u:User) WHERE u.home_location IS NOT NULL
+RETURN u.name AS user, u.metro_region AS metro, u.home_location AS coords
+LIMIT 5;
+----
+
+**Map card** — users with their rated movies:
+
+[source,cypher]
+----
+MATCH (u:User)-[r:RATED]->(m:Movie)
+WHERE u.home_location IS NOT NULL
+RETURN u, r, m;
+----
+
+**Companion bar chart** — average rating and volume by metro:
+
+[source,cypher]
+----
+MATCH (u:User)-[r:RATED]->(:Movie)
+WHERE u.metro_region IS NOT NULL
+RETURN u.metro_region             AS metro,
+       round(avg(r.rating), 1)    AS avg_rating,
+       count(r)                   AS total_ratings
+ORDER BY total_ratings DESC;
+----
+
+=== Seed 2: People by birth country
+
+`Person` nodes carry a `bornIn` property (a free-text string like `"Los Angeles, California, USA"` or `"France"`). This seed maps common country strings to their capital or geographic centroid.
+
+[source,cypher]
+----
+// Country-centroid coordinates derived from bornIn — educational approximations only.
+MATCH (p:Person)
+WHERE p.bornIn IS NOT NULL
+WITH p,
+  CASE
+    WHEN p.bornIn CONTAINS 'USA' OR p.bornIn CONTAINS 'United States'
+      THEN {country: 'USA',         lat:  39.50, lon:  -98.35}
+    WHEN p.bornIn CONTAINS 'England' OR p.bornIn CONTAINS 'Britain'
+         OR p.bornIn CONTAINS 'Scotland' OR p.bornIn CONTAINS 'Wales'
+         OR (p.bornIn CONTAINS 'UK' AND NOT p.bornIn CONTAINS 'Ukraine')
+      THEN {country: 'UK',          lat:  51.51, lon:   -0.13}
+    WHEN p.bornIn CONTAINS 'France'
+      THEN {country: 'France',      lat:  48.85, lon:    2.35}
+    WHEN p.bornIn CONTAINS 'Germany'
+      THEN {country: 'Germany',     lat:  52.52, lon:   13.40}
+    WHEN p.bornIn CONTAINS 'Italy'
+      THEN {country: 'Italy',       lat:  41.90, lon:   12.50}
+    WHEN p.bornIn CONTAINS 'Japan'
+      THEN {country: 'Japan',       lat:  35.68, lon:  139.69}
+    WHEN p.bornIn CONTAINS 'Australia'
+      THEN {country: 'Australia',   lat: -33.87, lon:  151.21}
+    WHEN p.bornIn CONTAINS 'Canada'
+      THEN {country: 'Canada',      lat:  43.65, lon:  -79.38}
+    WHEN p.bornIn CONTAINS 'Spain'
+      THEN {country: 'Spain',       lat:  40.42, lon:   -3.70}
+    WHEN p.bornIn CONTAINS 'India'
+      THEN {country: 'India',       lat:  19.07, lon:   72.88}
+    WHEN p.bornIn CONTAINS 'Sweden'
+      THEN {country: 'Sweden',      lat:  59.33, lon:   18.07}
+    WHEN p.bornIn CONTAINS 'Ireland' AND NOT p.bornIn CONTAINS 'Northern'
+      THEN {country: 'Ireland',     lat:  53.33, lon:   -6.25}
+    WHEN p.bornIn CONTAINS 'China'
+      THEN {country: 'China',       lat:  39.91, lon:  116.39}
+    WHEN p.bornIn CONTAINS 'Mexico'
+      THEN {country: 'Mexico',      lat:  19.43, lon:  -99.13}
+    WHEN p.bornIn CONTAINS 'Denmark'
+      THEN {country: 'Denmark',     lat:  55.68, lon:   12.57}
+    WHEN p.bornIn CONTAINS 'Israel'
+      THEN {country: 'Israel',      lat:  31.77, lon:   35.22}
+    WHEN p.bornIn CONTAINS 'Poland'
+      THEN {country: 'Poland',      lat:  52.23, lon:   21.01}
+    WHEN p.bornIn CONTAINS 'Russia' OR p.bornIn CONTAINS 'Soviet'
+      THEN {country: 'Russia',      lat:  55.75, lon:   37.62}
+    WHEN p.bornIn CONTAINS 'South Korea' OR p.bornIn CONTAINS 'Korea'
+      THEN {country: 'South Korea', lat:  37.57, lon:  126.98}
+    WHEN p.bornIn CONTAINS 'Brazil'
+      THEN {country: 'Brazil',      lat: -23.55, lon:  -46.63}
+    WHEN p.bornIn CONTAINS 'Argentina'
+      THEN {country: 'Argentina',   lat: -34.60, lon:  -58.38}
+    ELSE NULL
+  END AS geo
+WHERE geo IS NOT NULL
+SET p.birth_location = point({latitude: geo.lat, longitude: geo.lon}),
+    p.birth_country  = geo.country;
+----
+
+**Verify:**
+
+[source,cypher]
+----
+MATCH (p:Person) WHERE p.birth_location IS NOT NULL
+RETURN p.name AS person, p.bornIn AS raw, p.birth_country AS country
+LIMIT 5;
+----
+
+**Map card** — actors plotted at their birth country centroid:
+
+[source,cypher]
+----
+MATCH (p:Person:Actor)
+WHERE p.birth_location IS NOT NULL
+RETURN p;
+----
+
+**Companion bar chart** — number of actors per country:
+
+[source,cypher]
+----
+MATCH (p:Person:Actor)
+WHERE p.birth_country IS NOT NULL
+RETURN p.birth_country AS country, count(p) AS actor_count
+ORDER BY actor_count DESC
+LIMIT 15;
+----
+
+=== Seed 3: Movies by production country
+
+`Movie` nodes have a `countries` list (e.g. `["USA", "UK"]`). This seed maps the primary production country to a point.
+
+[source,cypher]
+----
+// Primary production country centroid — first entry in the countries list.
+MATCH (m:Movie)
+WHERE m.countries IS NOT NULL AND size(m.countries) > 0
+WITH m, m.countries[0] AS country
+WITH m, country,
+  CASE
+    WHEN country CONTAINS 'USA' OR country CONTAINS 'United States'
+      THEN point({latitude:  39.50, longitude:  -98.35})
+    WHEN country CONTAINS 'United Kingdom' OR country CONTAINS 'UK'
+         OR country CONTAINS 'England' OR country CONTAINS 'Britain'
+      THEN point({latitude:  51.51, longitude:   -0.13})
+    WHEN country CONTAINS 'France'
+      THEN point({latitude:  48.85, longitude:    2.35})
+    WHEN country CONTAINS 'Germany' OR country = 'West Germany'
+      THEN point({latitude:  52.52, longitude:   13.40})
+    WHEN country CONTAINS 'Italy'
+      THEN point({latitude:  41.90, longitude:   12.50})
+    WHEN country CONTAINS 'Japan'
+      THEN point({latitude:  35.68, longitude:  139.69})
+    WHEN country CONTAINS 'Australia'
+      THEN point({latitude: -33.87, longitude:  151.21})
+    WHEN country CONTAINS 'Canada'
+      THEN point({latitude:  43.65, longitude:  -79.38})
+    WHEN country CONTAINS 'Spain'
+      THEN point({latitude:  40.42, longitude:   -3.70})
+    WHEN country CONTAINS 'India'
+      THEN point({latitude:  19.07, longitude:   72.88})
+    WHEN country CONTAINS 'Sweden'
+      THEN point({latitude:  59.33, longitude:   18.07})
+    WHEN country CONTAINS 'Ireland'
+      THEN point({latitude:  53.33, longitude:   -6.25})
+    WHEN country CONTAINS 'China' OR country CONTAINS 'Hong Kong'
+      THEN point({latitude:  39.91, longitude:  116.39})
+    WHEN country CONTAINS 'Mexico'
+      THEN point({latitude:  19.43, longitude:  -99.13})
+    WHEN country CONTAINS 'Denmark'
+      THEN point({latitude:  55.68, longitude:   12.57})
+    WHEN country CONTAINS 'Israel'
+      THEN point({latitude:  31.77, longitude:   35.22})
+    WHEN country CONTAINS 'Poland'
+      THEN point({latitude:  52.23, longitude:   21.01})
+    WHEN country CONTAINS 'Russia' OR country CONTAINS 'Soviet'
+      THEN point({latitude:  55.75, longitude:   37.62})
+    WHEN country CONTAINS 'South Korea' OR country CONTAINS 'Korea'
+      THEN point({latitude:  37.57, longitude:  126.98})
+    WHEN country CONTAINS 'Brazil'
+      THEN point({latitude: -23.55, longitude:  -46.63})
+    WHEN country CONTAINS 'Argentina'
+      THEN point({latitude: -34.60, longitude:  -58.38})
+    ELSE NULL
+  END AS coords
+WHERE coords IS NOT NULL
+SET m.production_location = coords,
+    m.production_country  = country;
+----
+
+**Verify:**
+
+[source,cypher]
+----
+MATCH (m:Movie) WHERE m.production_location IS NOT NULL
+RETURN m.title AS movie, m.production_country AS country, m.production_location AS coords
+LIMIT 5;
+----
+
+**Map card** — movies plotted at their primary production country:
+
+[source,cypher]
+----
+MATCH (m:Movie)
+WHERE m.production_location IS NOT NULL
+RETURN m
+LIMIT 500;
+----
+
+**Companion bar chart** — average IMDb rating by production country:
+
+[source,cypher]
+----
+MATCH (m:Movie)
+WHERE m.production_country IS NOT NULL AND m.imdbRating IS NOT NULL
+RETURN m.production_country        AS country,
+       round(avg(m.imdbRating), 2) AS avg_imdb,
+       count(m)                    AS movie_count
+ORDER BY movie_count DESC
+LIMIT 15;
+----
+
+== Stretch ideas
+
+* Add a **filter** on region, country, or genre using link:https://neo4j.com/docs/aura/dashboards/parameters-and-filters/[Filters and parameters^] so the map and companion chart update together.
+* Combine seeds on one page — for example, a map of actors overlaid with movies from the same country.
+* Add a **Text** card noting which coordinates are approximations (all three seeds use centroids, not precise locations).
+
+read::Mark as completed[]
+
+[.summary]
+== Summary
+
+You added coordinates the Map card can read and built at least one non-map card beside it so the page tells a whole story.
+
+When that page is ready for other people, head to link:/courses/aura-dashboards/3-sharing-dashboards/[Sharing dashboards^].

--- a/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/module.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/module.adoc
@@ -3,7 +3,7 @@
 
 
 
-In this module, you will extend the dashboard you started in the introduction: describe the data model, add cards with AI and Cypher, add filters, organize pages and styling, then add aggregations and chart types.
+In this module, you will extend the dashboard you started in the introduction: describe the data model, add cards with AI and Cypher, add filters, organize pages and styling, then match chart types to your queries.
 
 You will:
 
@@ -11,7 +11,7 @@ You will:
 * Add cards with AI and Cypher and add a filter
 * *Challenge:* Build a parameterized Cypher card wired to a filter
 * Organize dashboard pages, import or export dashboard JSON, and style cards
-* Add aggregations and choose chart types for your metrics
+* Match visualization types to query results for your metrics
 * *Challenge:* Build a self-contained metrics page with three chart types
 * *(Optional)* Complete link:./5-map-dashboard-challenge/[Create a map dashboard^] for geographic cards
 

--- a/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/module.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/2-building-your-dashboard/module.adoc
@@ -1,15 +1,18 @@
-= Building your movies dashboard
+= Building your dashboard
 :order: 2
 
-This module builds on the dashboard you created in Getting Started. You describe the data model, add more cards and a filter, organize pages and styling, then add aggregations and chart types.
 
-In this module you will:
 
-* Describe the Movies graph model so you know what to query
+In this module, you will extend the dashboard you started in the introduction: describe the data model, add cards with AI and Cypher, add filters, organize pages and styling, then add aggregations and chart types.
+
+You will:
+
+* Describe your graph model so you know what to query (examples use the Movies recommendations dataset)
 * Add cards with AI and Cypher and add a filter
-* Organize dashboard pages and style cards
-* Add aggregations and choose chart types for ratings, genres, and actors
-
-By the end of this module you will have a working movies dashboard you can share in the next module.
+* *Challenge:* Build a parameterized Cypher card wired to a filter
+* Organize dashboard pages, import or export dashboard JSON, and style cards
+* Add aggregations and choose chart types for your metrics
+* *Challenge:* Build a self-contained metrics page with three chart types
+* *(Optional)* Complete link:./5-map-dashboard-challenge/[Create a map dashboard^] for geographic cards
 
 link:./1-describe-data-model/[Ready? Let's go →, role=btn]

--- a/asciidoc/courses/aura-dashboards/modules/3-sharing-dashboards/lessons/1-sharing/lesson.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/3-sharing-dashboards/lessons/1-sharing/lesson.adoc
@@ -53,7 +53,7 @@ image::images/1-project-viewer.png[Projects users screen showing the new user ad
 
 == Understanding user roles
 
-When sharing dashboards, it's important to understand the different user roles and what permissions they have:
+Before you share dashboards, read each role and what it can do:
 
 * **Organization Admin**: Has full access to all projects and instances within the organization. Can manage users, billing, and organization settings.
 * **Project Admin**: Has full access to all instances within a specific project. Can manage users and project settings.
@@ -70,13 +70,13 @@ Access to the Aura Console lets users manage projects and instances. Dashboard s
 
 == Sharing dashboards through email invitation
 
-Confirm that the users you have invited have accepted the invitation to join your project, and have the **Viewer** role for the project.
+Confirm invited users accepted and hold the **Viewer** role on the project.
 
-Once you have confirmed that the users have access to your project, share the dashboard with them by sending an email invitation:
+Then share the dashboard with them by email:
 
 image::images/invite-dashboard-viewer.png[invite dashboard viewer,width=600,align=center]
 
-After clicking the **Invite** button, the users will receive an email invitation to access the dashboard, and will be able to view all your pages created in that dashboard.
+After you click **Invite**, invited users get email with a link to the dashboard and can open every page you created in it.
 
 
 image::images/invite-dashboard-viewer-part2.png[invite dashboard viewer,width=600,align=center]

--- a/asciidoc/courses/aura-dashboards/modules/3-sharing-dashboards/lessons/1-sharing/lesson.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/3-sharing-dashboards/lessons/1-sharing/lesson.adoc
@@ -1,6 +1,6 @@
 = Sharing Dashboards
-:type: lesson
 :order: 1
+:type: lesson
 
 So far in this course you have created interactive dashboards with AI and Cypher. In this lesson you will learn:
 
@@ -68,7 +68,7 @@ Access to the Aura Console lets users manage projects and instances. Dashboard s
 ====
 
 
-== Sharing dashboards via email invitation
+== Sharing dashboards through email invitation
 
 Confirm that the users you have invited have accepted the invitation to join your project, and have the **Viewer** role for the project.
 
@@ -91,6 +91,12 @@ image::images/dashboards-access-settings.png[dashboard viewer access confirmed,w
 This scenario is useful when you want to share dashboards with a larger group of users without inviting them individually.
 
 
+== Click through sharing (no pressure to send mail)
+
+. Open a dashboard you actually built here.
+. Hit **Share** and read what the dialog offers—invite-by-email versus project-wide access. Close it if you are not inviting anyone yet.
+. Go to **Project** → **Settings** → **Users** and check **Project role** on your own row so you know where you stand before you invite others.
+. Only send a real invite if your team expects it; otherwise you have already seen the flow.
 
 
 [.quiz]
@@ -102,6 +108,6 @@ include::questions/1-choosing.adoc[leveloffset=+1]
 [.summary]
 == Summary
 
-In this lesson you learned how to share your dashboards with stakeholders by inviting users to your project and dashboards as Project Viewers. You also learned about different user roles and their permissions, ensuring the right people have access to make data-driven decisions.
+You now know how invites, project roles, and the **Share** dialog fit together.
 
-In the next lesson, you will learn about additional resources and next steps to continue building dashboards with the Movies dataset.
+Next: optional Learning Assistant prompts, then the final project and wrap-up.

--- a/asciidoc/courses/aura-dashboards/modules/3-sharing-dashboards/lessons/1-sharing/questions/1-choosing.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/3-sharing-dashboards/lessons/1-sharing/questions/1-choosing.adoc
@@ -1,7 +1,7 @@
 [.question]
 = Dashboard viewer role
 
-Stakeholders need to view your movies dashboard to use the insights. They must not edit dashboards or access the instance directly. Which role should you assign?
+Stakeholders need to view your dashboard to use the insights. They must not edit dashboards or access the instance directly. Which role should you assign?
 
 * [ ] Project Admin
 * [ ] Project Member

--- a/asciidoc/courses/aura-dashboards/modules/3-sharing-dashboards/lessons/2-ask-ai/lesson.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/3-sharing-dashboards/lessons/2-ask-ai/lesson.adoc
@@ -1,9 +1,11 @@
 = Ask AI
-:type: conversation
 :order: 2
+:type: conversation
 :optional: true
 
-In this lesson you will use the Learning Assistant to ask questions about dashboards and the Movies dataset. If you do not need help, skip to the next lesson.
+// TODO: Screenshot — GraphAcademy **Learning Assistant** panel open with a sample dashboards-related question (product UI varies by platform).
+
+In this lesson you will use the Learning Assistant to ask questions about dashboards, Cypher, and the Movies sample data (or your own schema). If you do not need help, skip to the next lesson.
 
 **Example questions you can try:**
 

--- a/asciidoc/courses/aura-dashboards/modules/3-sharing-dashboards/lessons/3-further-steps/lesson.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/3-sharing-dashboards/lessons/3-further-steps/lesson.adoc
@@ -1,19 +1,21 @@
-= Final Project: Build Your Stakeholders Dashboard
-:type: challenge
+= Final project: Build your stakeholders dashboard
 :order: 3
+:type: challenge
 
-In this lesson you will apply what you learned by building a stakeholders dashboard for the scenario below.
+Last exercise: build a small **stakeholders dashboard** from the scenario below. Use **Dashboards** as the main workspace; dip into **Query** or **Create with AI** when a card needs Cypher or a fresh AI pass.
 
-== Project Overview
+== Project overview
+
+// TODO: Screenshot — *(Optional)* Example “stakeholders” dashboard layout illustrating the scenario (not required for completion).
 
 **Scenario:** Design a dashboard for a streaming service to support content acquisition decisions. The dashboard will serve three stakeholder groups: executives, marketing team, and content acquisition team.
 
-**Dataset:** Use the Movies dataset you loaded earlier in this course (movies, actors, directors, genres, ratings).
+**Data:** Use your own graph in AuraDB, or the Movies sample dataset you loaded earlier in this course (movies, actors, directors, genres, ratings). If you use your own data, map the scenario to your labels (for example, products instead of movies).
 
 **Suggested steps:**
 
-. Add a page or cards that answer: Which genres have the most movies? Average rating by genre?
-. Add a card that shows top-rated movies or directors with highest average ratings.
+. Add a page or cards that answer: Which genres have the most movies? Average rating by genre? (Adapt the questions to your domain if you are not using Movies.)
+. Add a card that shows top-rated movies or directors with highest average ratings (or equivalent metrics on your graph).
 . Add at least one filter so stakeholders can change what is displayed (for example, filter by person name or genre).
 . Share the dashboard with a colleague or mark it complete and review the cards you built.
 
@@ -30,7 +32,7 @@ read::Mark as completed[]
 [.summary]
 == Summary
 
-In this lesson you received the final project: build a stakeholders dashboard for a streaming service.
+In this lesson you received the final project: build a stakeholders dashboard for a streaming service, using the Movies sample data or your own graph.
 
 You also learned how to share your work with the Neo4j community to build your portfolio, get feedback, and connect with other Neo4j users.
 

--- a/asciidoc/courses/aura-dashboards/modules/3-sharing-dashboards/lessons/3-further-steps/lesson.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/3-sharing-dashboards/lessons/3-further-steps/lesson.adoc
@@ -12,7 +12,7 @@ Last exercise: build a small **stakeholders dashboard** from the scenario below.
 
 **Data:** Use your own graph in AuraDB, or the Movies sample dataset you loaded earlier in this course (movies, actors, directors, genres, ratings). If you use your own data, map the scenario to your labels (for example, products instead of movies).
 
-**Suggested steps:**
+**Complete these steps:**
 
 . Add a page or cards that answer: Which genres have the most movies? Average rating by genre? (Adapt the questions to your domain if you are not using Movies.)
 . Add a card that shows top-rated movies or directors with highest average ratings (or equivalent metrics on your graph).

--- a/asciidoc/courses/aura-dashboards/modules/3-sharing-dashboards/module.adoc
+++ b/asciidoc/courses/aura-dashboards/modules/3-sharing-dashboards/module.adoc
@@ -1,12 +1,14 @@
 = Sharing your dashboard
 :order: 3
 
-Share your movies dashboard with others so they can view and interact with it.
 
-In this module you will:
+
+In this module, you will share the dashboard you built so others can view and interact with it.
+
+By the end of this module, you will be able to:
 
 * Share your dashboard with specific users or project-wide
 * Use sharing options and access settings in Neo4j Dashboards
-* Review user roles and permissions
+* Review user roles and permissions in the Aura Console
 
 link:./1-sharing/[Ready? Let's go →, role=btn]

--- a/asciidoc/courses/aura-dashboards/summary.adoc
+++ b/asciidoc/courses/aura-dashboards/summary.adoc
@@ -1,28 +1,67 @@
 = Course Summary
 
-You have completed the Neo4j Dashboards course and built a movies dashboard from start to finish.
+Congratulations on completing the Neo4j Dashboards course!
 
-== Module 1: Getting started
+You have connected Aura Dashboards to your graph, built cards with AI and Cypher, organized pages and chart types, and learned how to share your work with others in the Aura Console.
 
-You now have the knowledge to:
+== Understanding Neo4j Dashboards
+
+You now know how to:
 
 * Explain what Neo4j Dashboards are and when to use them
-* Access Dashboards in Aura and connect to your instance
-* Load the Movies dataset and create your first cards with AI
+* Open Dashboards in Aura, connect to your instance, and work within dashboard limits for your tier
+* Load the Movies sample dataset or adapt the examples to your own labels and relationships
+* Create your first dashboard with AI
 
-== Module 2: Building your movies dashboard
+== Building your dashboard
 
-You now have the knowledge to:
+You now know how to:
 
-* Describe the Movies graph model and map it to dashboard cards
-* Add cards with AI and natural language, and with Cypher for precise control
-* Create pages, style cards, and choose chart types (graph, table, bar, pie, single value, text)
-* Use aggregations to visualize ratings, genres, and actors
+* Describe your graph model (node labels, relationships, properties) and tie stakeholder questions to cards
+* Add cards with natural language and with Cypher; add filters and use the parameters drawer
+* Organize dashboard pages; style cards in the Results overview; import or export dashboard JSON
+* Use aggregations and choose visualization types: graph, table, bar, pie, single value, line, text
+* *(Optional)* Complete the link:/courses/aura-dashboards/2-building-your-dashboard/5-map-dashboard-challenge/[Create a map dashboard^] challenge after aggregations if you need Map cards
 
-== Module 3: Sharing your dashboard
+== Sharing dashboards
 
-You now have the knowledge to:
+You now know how to:
 
-* Share your dashboard with specific users or project-wide
+* Share a dashboard with specific users or project-wide
 * Use sharing options and access settings in Neo4j Dashboards
-* Apply user roles and permissions
+* Apply user roles and permissions in the Aura Console
+
+== Best practices
+
+=== Data and queries
+
+* Inspect your schema with `CALL db.schema.visualization` before designing cards so your Cypher matches real labels and relationship types.
+* When you use your own graph, replace Movies-specific examples (for example `Movie`, `ACTED_IN`) with your domain labels and patterns.
+* Be specific in AI prompts about node labels and relationship types so generated Cypher matches your model.
+
+=== Dashboard design
+
+* Choose a visualization type that matches the shape of your query result (graph for nodes and relationships, table for rows, single value for one metric).
+* Add filters when viewers need to slice the same cards by a parameter (for example name, category, or date range).
+
+=== Sharing and access
+
+* Dashboard access follows **project roles** (Viewer, Member, Admin); match the role to whether someone should only view dashboards or change projects and data.
+* Invite from the **Share** dialog after people belong to the project—strangers cannot see the dashboard just from a link unless your access settings allow it.
+
+== Want to Learn More?
+
+* link:https://neo4j.com/docs/aura/dashboards/[Neo4j Aura Dashboards documentation^] — Overview, Create with AI, Create with Cypher, link:https://neo4j.com/docs/aura/dashboards/managing-dashboards/[Managing dashboards^], link:https://neo4j.com/docs/aura/dashboards/import/[Import and export^], link:https://neo4j.com/docs/aura/dashboards/parameters-and-filters/[Filters and parameters^], sharing, and visualization types (including link:https://neo4j.com/docs/aura/dashboards/visualizations/map/[Map^])
+* link:https://neo4j.com/docs/aura/aura-agent/[Aura Agent documentation^] — Same AuraDB instance as Dashboards; dashboards still query only data you store in the graph
+
+== Ready for your next challenge?
+
+To build on graph querying and Aura:
+
+* link:/courses/cypher-fundamentals/[Cypher Fundamentals^] - Core query patterns for Neo4j
+* link:/courses/cypher-aggregation/[Cypher Aggregation^] - Aggregations and grouping
+* link:/courses/aura-fundamentals/[Aura Fundamentals^] - Managing Aura instances and the Aura Console
+
+Related Aura and GenAI courses:
+
+* link:/courses/aura-agents/[Building Agents in Neo4j Aura^] - Agents on the same graph you chart in Dashboards

--- a/asciidoc/courses/aura-dashboards/summary.adoc
+++ b/asciidoc/courses/aura-dashboards/summary.adoc
@@ -20,8 +20,8 @@ You now know how to:
 * Describe your graph model (node labels, relationships, properties) and tie stakeholder questions to cards
 * Add cards with natural language and with Cypher; add filters and use the parameters drawer
 * Organize dashboard pages; style cards in the Results overview; import or export dashboard JSON
-* Use aggregations and choose visualization types: graph, table, bar, pie, single value, line, text
-* *(Optional)* Complete the link:/courses/aura-dashboards/2-building-your-dashboard/5-map-dashboard-challenge/[Create a map dashboard^] challenge after aggregations if you need Map cards
+* Match visualization types to aggregation results: graph, table, bar, pie, single value, line, text
+* *(Optional)* Complete the link:/courses/aura-dashboards/2-building-your-dashboard/5-map-dashboard-challenge/[Create a map dashboard^] challenge after that lesson if you need Map cards
 
 == Sharing dashboards
 


### PR DESCRIPTION

## General Update PR

Aura Dashboards course update


**Course:** Prerequisites say “Complete the following courses first:”; 14 lessons in course.adoc.
**Summary:** Building section wording aligned with matching visualization types to aggregation results; optional map challenge is after that lesson.
**Aura Agents:** Same prerequisite like in aura-agents/course.adoc.
**New lesson:** 2-load-sample-data — Movies dump, backup/restore, verify, optional CSV, completion marker.
**Lesson 1:** 1-what-are-dashboards shortened; sample-data steps live in lesson 2.
**Lessons 2–3 (module 1):** Orders/copy updated; #sample-graph-data links go to 2-load-sample-data.
**Requirements question:** Hints/solutions point to 2-load-sample-data.
**Module 1 overview:** Bullets updated for load → connect → explore.
**Module 2 lessons:** Shorter 1-describe-data-model, 2-build-with-ai, 4-visualise-aggregations (“Match chart types to your query”); 3-first-card “next” line updated.
**Challenges:** 2b, 4b, 5-map-dashboard-challenge wired and cross-linked; map challenge collapsible closed correctly before Stretch ideas.
**Module 2 overview:** Copy matches matching chart types to queries (not old “add aggregations and choose chart types” framing).
**Sharing:** 1-sharing voice/roles/invite tweaks; 3-further-steps uses “Complete these steps:” where needed.

QA: npx jest tests/qa.test.js -t "aura-dashboards" passes.

## Testing

- [x] Tested locally
- [x] All existing tests pass
