### PR TITLE
Update to use toFloatList to return VECTOR

### DIFF
--- a/asciidoc/courses/genai-fundamentals/modules/2-rag/lessons/3-vector-index/lesson.adoc
+++ b/asciidoc/courses/genai-fundamentals/modules/2-rag/lessons/3-vector-index/lesson.adoc
@@ -178,7 +178,7 @@ WITH ai.text.embed(
     "OpenAI",
     { token: "sk-...", model: "text-embedding-ada-002" }
 ) AS embedding
-RETURN embedding
+RETURN toFloatList(embedding)
 ----
 ====
 

--- a/asciidoc/courses/llm-vectors-unstructured/modules/2-vector-indexes/lessons/5-query-vector-index/lesson.adoc
+++ b/asciidoc/courses/llm-vectors-unstructured/modules/2-vector-indexes/lessons/5-query-vector-index/lesson.adoc
@@ -108,7 +108,7 @@ WITH ai.text.embed(
     "OpenAI", 
     { token: "sk-...", model: "text-embedding-ada-002" }
 ) AS embedding
-RETURN embedding
+RETURN toFloatList(embedding)
 ----
 
 [IMPORTANT]


### PR DESCRIPTION
## General Update PR

## Description

Temporary fix to use `toFloatList` to VECTOR data types as the the GraphAcademy browser doesnt currently support the VECTOR type.

## Testing

- [x] Tested locally
- [x] All existing tests pass
