### PR TITLE
make entity label extraction order independent and drop null fields

### DIFF
--- a/asciidoc/courses/workshop-genai/modules/3-retrieval/lessons/2-vector-cypher-retriever/lesson.adoc
+++ b/asciidoc/courses/workshop-genai/modules/3-retrieval/lessons/2-vector-cypher-retriever/lesson.adoc
@@ -148,10 +148,18 @@ This cypher query retrieves all related entities between the chunks:
 .Related entities
 ----
 MATCH (c:Chunk)<-[:FROM_CHUNK]-(entity)-[r]->(other)-[:FROM_CHUNK]->()
-RETURN DISTINCT 
-  labels(entity)[2], entity.name, entity.type, entity.description, 
-  type(r), 
-  labels(other)[2], other.name, other.type, other.description
+WITH
+  entity,
+  other,
+  r,
+  [l IN labels(entity)
+    WHERE NOT l IN ["__KGBuilder__", "__Entity__"]][0] AS entityLabel,
+  [l IN labels(other)
+    WHERE NOT l IN ["__KGBuilder__", "__Entity__"]][0] AS otherLabel
+RETURN DISTINCT
+  entityLabel, entity.name,
+  type(r),
+  otherLabel, other.name
 ----
 
 The output uses the node labels, properties, and relationship types to output rows which form statements such as:


### PR DESCRIPTION
This is a companion commit to the commit in code repo: neo4j-graphacademy/workshop-genai@5b664346
That makes the calling approach consistent.

## Choose a Pull Request Template

Please choose the appropriate template for your PR:

- [Course Draft Template](?template=course_draft.md)
- [Course Release Template](?template=course_release.md)
- [Course Fix Template](?template=course_fix.md)
- [General Update Template] (continue with this template)

---

## General Update PR

## Description

Brief description of changes made.

## Related Issues

- Closes #[issue number]

## Testing

- [ X ] Tested locally
- [ X ] All existing tests pass
