### PR TITLE
Fix data URL slugs missed in workshop-lakehouse rename

### DIFF
--- a/asciidoc/courses/workshop-lakehouse/data/generate.py
+++ b/asciidoc/courses/workshop-lakehouse/data/generate.py
@@ -1,6 +1,6 @@
 """Generate the AutoFix Group sample dataset.
 
-Deterministic generator for the genai-workshop-lakehouse course data.
+Deterministic generator for the workshop-lakehouse course data.
 The CSVs model two halves of a lakehouse:
 
 - Document side (parsed PDFs): documents, sections, section_refs

--- a/asciidoc/courses/workshop-lakehouse/data/load-documents.cypher
+++ b/asciidoc/courses/workshop-lakehouse/data/load-documents.cypher
@@ -8,7 +8,7 @@ CREATE CONSTRAINT part_number IF NOT EXISTS FOR (p:Part) REQUIRE p.partNumber IS
 CREATE CONSTRAINT dtc_code IF NOT EXISTS FOR (c:DTC) REQUIRE c.code IS UNIQUE;
 
 // Documents — one node per PDF
-LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/genai-workshop-lakehouse/documents.csv' AS row
+LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/workshop-lakehouse/documents.csv' AS row
 MERGE (d:Document {id: row.doc_id})
 SET d.docType = row.doc_type,
     d.title = row.title,
@@ -21,35 +21,35 @@ MATCH (d:Document {docType: 'Bulletin'}) SET d:Bulletin;
 MATCH (d:Document {docType: 'RecallNotice'}) SET d:RecallNotice;
 
 // Sections — the tree
-LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/genai-workshop-lakehouse/sections.csv' AS row
+LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/workshop-lakehouse/sections.csv' AS row
 MERGE (s:Section {id: row.section_id})
 SET s.seq = toInteger(row.seq),
     s.title = row.title,
     s.text = row.text;
 
 // Top-level sections hang off the document...
-LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/genai-workshop-lakehouse/sections.csv' AS row
+LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/workshop-lakehouse/sections.csv' AS row
 WITH row WHERE row.parent_id IS NULL OR row.parent_id = ''
 MATCH (d:Document {id: row.doc_id})
 MATCH (s:Section {id: row.section_id})
 MERGE (d)-[:HAS_SECTION]->(s);
 
 // ...subsections hang off their parent section
-LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/genai-workshop-lakehouse/sections.csv' AS row
+LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/workshop-lakehouse/sections.csv' AS row
 WITH row WHERE row.parent_id IS NOT NULL AND row.parent_id <> ''
 MATCH (parent:Section {id: row.parent_id})
 MATCH (s:Section {id: row.section_id})
 MERGE (parent)-[:HAS_SECTION]->(s);
 
 // Shared keys — part numbers mentioned in section text
-LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/genai-workshop-lakehouse/section_refs.csv' AS row
+LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/workshop-lakehouse/section_refs.csv' AS row
 WITH row WHERE row.ref_type = 'PART'
 MATCH (s:Section {id: row.section_id})
 MERGE (p:Part {partNumber: row.ref_value})
 MERGE (s)-[:REFERENCES_PART]->(p);
 
 // Shared keys — diagnostic trouble codes mentioned in section text
-LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/genai-workshop-lakehouse/section_refs.csv' AS row
+LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/workshop-lakehouse/section_refs.csv' AS row
 WITH row WHERE row.ref_type = 'CODE'
 MATCH (s:Section {id: row.section_id})
 MERGE (c:DTC {code: row.ref_value})

--- a/asciidoc/courses/workshop-lakehouse/data/load-warehouse.cypher
+++ b/asciidoc/courses/workshop-lakehouse/data/load-warehouse.cypher
@@ -7,12 +7,12 @@ CREATE CONSTRAINT procedure_id IF NOT EXISTS FOR (p:Procedure) REQUIRE p.id IS U
 
 // Parts catalog (Delta: autofix.service.part)
 // MERGE on partNumber — enriches the Part nodes the PDFs already created
-LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/genai-workshop-lakehouse/parts.csv' AS row
+LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/workshop-lakehouse/parts.csv' AS row
 MERGE (p:Part {partNumber: row.part_number})
 SET p.name = row.name;
 
 // Supersession chain
-LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/genai-workshop-lakehouse/parts.csv' AS row
+LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/workshop-lakehouse/parts.csv' AS row
 WITH row WHERE row.superseded_by IS NOT NULL AND row.superseded_by <> ''
 MATCH (old:Part {partNumber: row.part_number})
 MATCH (new:Part {partNumber: row.superseded_by})
@@ -20,18 +20,18 @@ MERGE (old)-[:SUPERSEDED_BY]->(new);
 
 // Trouble code reference (Delta: autofix.service.dtc_code)
 // MERGE on code — enriches the DTC nodes the PDFs already created
-LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/genai-workshop-lakehouse/dtc_codes.csv' AS row
+LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/workshop-lakehouse/dtc_codes.csv' AS row
 MERGE (c:DTC {code: row.code})
 SET c.description = row.description;
 
 // Procedures (Delta: autofix.service.procedure)
-LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/genai-workshop-lakehouse/procedures.csv' AS row
+LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/workshop-lakehouse/procedures.csv' AS row
 MERGE (p:Procedure {id: row.procedure_id})
 SET p.name = row.name,
     p.laborHours = toFloat(row.labor_hours);
 
 // Vehicles (Delta: autofix.service.vehicle)
-LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/genai-workshop-lakehouse/vehicles.csv' AS row
+LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/workshop-lakehouse/vehicles.csv' AS row
 MERGE (v:Vehicle {vin: row.vin})
 SET v.make = row.make,
     v.model = row.model,
@@ -39,7 +39,7 @@ SET v.make = row.make,
     v.engine = row.engine;
 
 // Work orders (Delta: autofix.service.work_order)
-LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/genai-workshop-lakehouse/work_orders.csv' AS row
+LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/workshop-lakehouse/work_orders.csv' AS row
 MERGE (w:WorkOrder {id: row.wo_id})
 SET w.opened = date(row.opened),
     w.odometer = toInteger(row.odometer),
@@ -53,7 +53,7 @@ MATCH (p:Procedure {id: row.procedure_id})
 MERGE (w)-[:PERFORMED]->(p);
 
 // Diagnosed codes — the DTC node is the same one the PDF sections reference
-LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/genai-workshop-lakehouse/work_orders.csv' AS row
+LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/workshop-lakehouse/work_orders.csv' AS row
 WITH row WHERE row.dtc_code IS NOT NULL AND row.dtc_code <> ''
 MATCH (w:WorkOrder {id: row.wo_id})
 MATCH (c:DTC {code: row.dtc_code})
@@ -61,7 +61,7 @@ MERGE (w)-[:DIAGNOSED]->(c);
 
 // Replaced parts (Delta: autofix.service.work_order_part)
 // The Part node is the same one the PDF sections reference
-LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/genai-workshop-lakehouse/work_order_parts.csv' AS row
+LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/workshop-lakehouse/work_order_parts.csv' AS row
 MATCH (w:WorkOrder {id: row.wo_id})
 MATCH (p:Part {partNumber: row.part_number})
 MERGE (w)-[r:REPLACED]->(p)

--- a/asciidoc/courses/workshop-lakehouse/modules/2-navigate-documents/lessons/2-navigation-tools/solution.cypher
+++ b/asciidoc/courses/workshop-lakehouse/modules/2-navigate-documents/lessons/2-navigation-tools/solution.cypher
@@ -3,7 +3,7 @@ CREATE CONSTRAINT section_id IF NOT EXISTS FOR (s:Section) REQUIRE s.id IS UNIQU
 CREATE CONSTRAINT part_number IF NOT EXISTS FOR (p:Part) REQUIRE p.partNumber IS UNIQUE;
 CREATE CONSTRAINT dtc_code IF NOT EXISTS FOR (c:DTC) REQUIRE c.code IS UNIQUE;
 
-LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/genai-workshop-lakehouse/documents.csv' AS row
+LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/workshop-lakehouse/documents.csv' AS row
 MERGE (d:Document {id: row.doc_id})
 SET d.docType = row.doc_type,
     d.title = row.title,
@@ -14,31 +14,31 @@ MATCH (d:Document {docType: 'Manual'}) SET d:Manual;
 MATCH (d:Document {docType: 'Bulletin'}) SET d:Bulletin;
 MATCH (d:Document {docType: 'RecallNotice'}) SET d:RecallNotice;
 
-LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/genai-workshop-lakehouse/sections.csv' AS row
+LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/workshop-lakehouse/sections.csv' AS row
 MERGE (s:Section {id: row.section_id})
 SET s.seq = toInteger(row.seq),
     s.title = row.title,
     s.text = row.text;
 
-LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/genai-workshop-lakehouse/sections.csv' AS row
+LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/workshop-lakehouse/sections.csv' AS row
 WITH row WHERE row.parent_id IS NULL OR row.parent_id = ''
 MATCH (d:Document {id: row.doc_id})
 MATCH (s:Section {id: row.section_id})
 MERGE (d)-[:HAS_SECTION]->(s);
 
-LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/genai-workshop-lakehouse/sections.csv' AS row
+LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/workshop-lakehouse/sections.csv' AS row
 WITH row WHERE row.parent_id IS NOT NULL AND row.parent_id <> ''
 MATCH (parent:Section {id: row.parent_id})
 MATCH (s:Section {id: row.section_id})
 MERGE (parent)-[:HAS_SECTION]->(s);
 
-LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/genai-workshop-lakehouse/section_refs.csv' AS row
+LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/workshop-lakehouse/section_refs.csv' AS row
 WITH row WHERE row.ref_type = 'PART'
 MATCH (s:Section {id: row.section_id})
 MERGE (p:Part {partNumber: row.ref_value})
 MERGE (s)-[:REFERENCES_PART]->(p);
 
-LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/genai-workshop-lakehouse/section_refs.csv' AS row
+LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/workshop-lakehouse/section_refs.csv' AS row
 WITH row WHERE row.ref_type = 'CODE'
 MATCH (s:Section {id: row.section_id})
 MERGE (c:DTC {code: row.ref_value})
@@ -59,33 +59,33 @@ CREATE CONSTRAINT vehicle_vin IF NOT EXISTS FOR (v:Vehicle) REQUIRE v.vin IS UNI
 CREATE CONSTRAINT work_order_id IF NOT EXISTS FOR (w:WorkOrder) REQUIRE w.id IS UNIQUE;
 CREATE CONSTRAINT procedure_id IF NOT EXISTS FOR (p:Procedure) REQUIRE p.id IS UNIQUE;
 
-LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/genai-workshop-lakehouse/parts.csv' AS row
+LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/workshop-lakehouse/parts.csv' AS row
 MERGE (p:Part {partNumber: row.part_number})
 SET p.name = row.name;
 
-LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/genai-workshop-lakehouse/parts.csv' AS row
+LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/workshop-lakehouse/parts.csv' AS row
 WITH row WHERE row.superseded_by IS NOT NULL AND row.superseded_by <> ''
 MATCH (old:Part {partNumber: row.part_number})
 MATCH (new:Part {partNumber: row.superseded_by})
 MERGE (old)-[:SUPERSEDED_BY]->(new);
 
-LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/genai-workshop-lakehouse/dtc_codes.csv' AS row
+LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/workshop-lakehouse/dtc_codes.csv' AS row
 MERGE (c:DTC {code: row.code})
 SET c.description = row.description;
 
-LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/genai-workshop-lakehouse/procedures.csv' AS row
+LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/workshop-lakehouse/procedures.csv' AS row
 MERGE (p:Procedure {id: row.procedure_id})
 SET p.name = row.name,
     p.laborHours = toFloat(row.labor_hours);
 
-LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/genai-workshop-lakehouse/vehicles.csv' AS row
+LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/workshop-lakehouse/vehicles.csv' AS row
 MERGE (v:Vehicle {vin: row.vin})
 SET v.make = row.make,
     v.model = row.model,
     v.year = toInteger(row.year),
     v.engine = row.engine;
 
-LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/genai-workshop-lakehouse/work_orders.csv' AS row
+LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/workshop-lakehouse/work_orders.csv' AS row
 MERGE (w:WorkOrder {id: row.wo_id})
 SET w.opened = date(row.opened),
     w.odometer = toInteger(row.odometer),
@@ -98,13 +98,13 @@ WITH w, row
 MATCH (p:Procedure {id: row.procedure_id})
 MERGE (w)-[:PERFORMED]->(p);
 
-LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/genai-workshop-lakehouse/work_orders.csv' AS row
+LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/workshop-lakehouse/work_orders.csv' AS row
 WITH row WHERE row.dtc_code IS NOT NULL AND row.dtc_code <> ''
 MATCH (w:WorkOrder {id: row.wo_id})
 MATCH (c:DTC {code: row.dtc_code})
 MERGE (w)-[:DIAGNOSED]->(c);
 
-LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/genai-workshop-lakehouse/work_order_parts.csv' AS row
+LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/workshop-lakehouse/work_order_parts.csv' AS row
 MATCH (w:WorkOrder {id: row.wo_id})
 MATCH (p:Part {partNumber: row.part_number})
 MERGE (w)-[r:REPLACED]->(p)


### PR DESCRIPTION
Follow-up to #575: four files kept `data.neo4j.com/genai-workshop-lakehouse` URLs after the course folder was renamed to `workshop-lakehouse` (edits were made but not staged into the rename commit). Reference load scripts and one solution.cypher only — no lesson content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)