### PR TITLE
lakehouse-workshop: move document load into M3, teach agent-written Cypher

### DIFF
--- a/asciidoc/courses/workshop-lakehouse/course.adoc
+++ b/asciidoc/courses/workshop-lakehouse/course.adoc
@@ -53,6 +53,7 @@ For the hands-on path you will need a coding agent (this workshop assumes Claude
 * When to derive a graph and when to federate - the four-pains decision
 * How an agent judges live - retrieving warehouse schema from the connections graph and writing Text2SQL grounded in Neo4j, on the shared key
 * How an agent decides and acts on policy - grounding, evidence, recalls, escalation - with an auditable trail
+* How to write graph queries with a coding agent - driving the neo4j-cypher-skill from a spec instead of hand-writing Cypher
 * How to build an agent skill a coding agent runs through the Neo4j CLI, and port the pattern to another lakehouse
 
 [.includes]

--- a/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/lessons/2-your-environment/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/lessons/2-your-environment/lesson.adoc
@@ -68,19 +68,9 @@ Otherwise set `ANTHROPIC_API_KEY` in the same `.env` file - use the key provided
 
 
 [.slide]
-== Load the documents
+== Start the parts API
 
-One command builds the document graph - **documents only**. The warehouse rows stay in BigQuery; you connect to them in the next module.
-
-[source,shell]
-.Parse the PDFs into the graph
-----
-python load/load_documents.py
-----
-
-You should see the pipeline parse the PDF library into one Library tree - 3 folders, 183 documents, 985 sections, threaded by reading order (`NEXT_SECTION`) and the documents' own cross-references (`LINKS_TO`) - and finish with `warehouse rows stay in BigQuery`. The document half comes from **real PDFs**; the parser is the same shape a production pipeline would run over cloud storage.
-
-Then start the parts API in a second terminal - your agent acts through it in Module 5:
+Start the mock dealer-management API in a second terminal - your agent acts through it in Module 5:
 
 [source,shell]
 .Start the mock dealer-management API
@@ -88,20 +78,22 @@ Then start the parts API in a second terminal - your agent acts through it in Mo
 uvicorn api.parts_api:app --port 8800
 ----
 
+Your sandbox is empty for now. You build the **connections** graph in the next module and load the **document** graph in Module 3 - each at the point you need it.
+
 
 [.slide]
 == Meet your agent
 
-Start your coding agent in the repository root and ask it something only the graph can answer:
+Start your coding agent in the repository root and confirm it can reach your sandbox:
 
 [source,shell]
 .Smoke test
 ----
 claude
-> What is in the Neo4j database described by .env? Give me counts by label.
+> How many nodes are in the Neo4j database described by .env?
 ----
 
-The agent uses the Neo4j skills to inspect the graph: 1 Library, 3 folders, 183 documents, 985 sections, threaded by reading order and the documents' own cross-references. Part numbers and trouble codes are not nodes here - they live in the section text (and in BigQuery); the warehouse rows are not here either - they are in BigQuery, where you will reach them in the finale.
+The agent uses the Neo4j skills to connect and reports **zero** - the sandbox is empty until you start loading it. That is the wiring confirmed: the agent can read your `.env`, reach the sandbox, and run Cypher.
 The sandbox window on the right is your inspection surface throughout: when a tool returns ids or URIs, look at them there as a graph.
 
 read::Continue[]
@@ -114,7 +106,7 @@ In this lesson, you set up your environment:
 
 * **Codespace** - Python, neo4j-cli with agent skills, neocarta, and Claude Code, preinstalled
 * **Both halves connected** - Neo4j sandbox credentials + read-only access to the BigQuery warehouse
-* **Documents loaded** - the PDFs parsed into the graph; the warehouse rows stay in BigQuery
-* **Parts API + smoke test** - your agent can already inspect the document graph
+* **Parts API running** - the mock dealer-management API your agent acts through in Module 5
+* **Agent wired up** - it can read `.env`, reach the (empty) sandbox, and run Cypher; you fill the graph in Modules 2 and 3
 
 In the next module, you build the connections shape: neocarta reads the warehouse's join paths from BigQuery.

--- a/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/lessons/2-your-environment/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/lessons/2-your-environment/lesson.adoc
@@ -1,7 +1,7 @@
 = Your Environment
 :type: lesson
 :order: 2
-:duration: 6
+:duration: 8
 :sandbox: true
 
 
@@ -96,6 +96,23 @@ claude
 The agent uses the Neo4j skills to connect and reports **zero** - the sandbox is empty until you start loading it. That is the wiring confirmed: the agent can read your `.env`, reach the sandbox, and run Cypher.
 The sandbox window on the right is your inspection surface throughout: when a tool returns ids or URIs, look at them there as a graph.
 
+
+[.slide]
+== You will not hand-write the Cypher
+
+The tools you build in the coming modules - `outline.py`, `search.py`, `themes.py` - run on **Cypher**, Neo4j's graph query language. This workshop is about _shapes_, not syntax, so we do not teach Cypher here. If you want the language itself, link:https://graphacademy.neo4j.com/courses/cypher-fundamentals[Cypher Fundamentals^] covers it in about an hour, free.
+
+Instead you do what you would on the job: hand your coding agent a **spec** and let it write the Cypher. That is why setup installed a curated set of the link:https://neo4j.com/labs/genai-ecosystem/agent-skills/[Neo4j agent skills^] - chief among them the **neo4j-cypher-skill**, which teaches your agent to write correct, current Cypher from a description of the shape you want (plus the **neo4j-gds-skill** you use for community detection in Module 4). Each tool ships with its plumbing done and one query marked `BUILD FROM SPEC` - that query is what you and your agent fill in.
+
+[NOTE]
+.How the skills got there
+====
+The Codespace installed them for you in `.devcontainer/post-create.sh`, which runs the `neo4j-cli` installer from link:https://neo4j.sh[neo4j.sh^] and then `neo4j-cli skill install` for the self-skill plus `neo4j-cypher-skill` and `neo4j-gds-skill`. The optional Module 4 lesson _Graph Reasoning with neo4j-cli_ shows the same CLI used directly for ad-hoc reasoning.
+====
+
+
+When you reach those challenges, you will hand your agent the spec and let it wire each query - the exact prompts are in the lessons where you do it.
+
 read::Continue[]
 
 
@@ -108,5 +125,6 @@ In this lesson, you set up your environment:
 * **Both halves connected** - Neo4j sandbox credentials + read-only access to the BigQuery warehouse
 * **Parts API running** - the mock dealer-management API your agent acts through in Module 5
 * **Agent wired up** - it can read `.env`, reach the (empty) sandbox, and run Cypher; you fill the graph in Modules 2 and 3
+* **Cypher is the agent's job** - you build each tool's `BUILD FROM SPEC` query by prompting your agent with the neo4j-cypher-skill, not by hand
 
 In the next module, you build the connections shape: neocarta reads the warehouse's join paths from BigQuery.

--- a/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/module.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/module.adoc
@@ -11,5 +11,9 @@ By the end of this module, you will:
 * Name the three graph shapes this workshop builds: trees, communities, and paths
 * Have a running Codespace, a loaded graph, and a coding agent connected to both
 
+// TODO: CLI exists - consider mentioning here.  we do't have it integrated but that is fine
+
+// TODO: Pin Neocarta version to keep things from breaking in the import and MCP server
+
 
 link:./1-workshop-overview/[Ready? Let's go →, role=btn]

--- a/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/1-documents-are-graphs/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/1-documents-are-graphs/lesson.adoc
@@ -2,6 +2,7 @@
 :type: lesson
 :order: 1
 :duration: 7
+:sandbox: true
 
 
 [.slide.discrete]
@@ -17,7 +18,7 @@ To _navigate_ a library, an agent needs something a pile of chunks can't give it
 [.slide]
 == Give the agent a table of contents
 
-A table of contents is a map: it shows what's in the library and where, and it lets you jump straight to the part you need. Hand that same map to an agent and it can do the same thing - read the outline, reason about which entry answers the question, and open only that section. **Navigation instead of similarity.**
+A table of contents is a map: it shows what's in the library and where, and it lets you jump straight to the part you need. It's is how humans navigate large documents and libraries. Hand that same map to an agent and it can do the same thing - read the outline, reason about which entry answers the question, and open only that section. **Navigation instead of similarity.**
 
 This is a proven pattern, not a hunch. link:https://pageindex.ai/blog/pageindex-intro[PageIndex^] builds a hierarchical table of contents over a document and has an LLM reason _down the tree_ to the right section - no embeddings, no chunking. On FinanceBench (question-answering over real SEC filings) the approach reports **98.7% accuracy, against roughly 50% for naive vector RAG**.footnote:[The conceptual precursor is Prompt-RAG (Kang et al., link:https://arxiv.org/abs/2401.11246[arXiv:2401.11246^]): let the LLM pick headings from a document's ToC and pass those sections as context.]
 
@@ -33,7 +34,7 @@ AutoFix Technical Library .......................... L   technical-library
       Cause ........................................ S   technical-library/bulletins/tsb-20-501.pdf#cause
 ----
 
-Names on the left for a human to read; full URIs on the right that the agent copies back into a tool to drill in or pull the text. The agent never has to guess where a passage lives - the address travels with it.
+Names on the left for a human to read; full URIs on the right that the agent copies back into a tool to drill in or pull the text.
 
 
 [.slide]
@@ -41,9 +42,9 @@ Names on the left for a human to read; full URIs on the right that the agent cop
 
 A single document's table of contents is a **tree**: the library contains folders, folders contain documents, documents contain sections, sections nest into sub-sections. One containment relationship, `HAS`, walks the whole thing top-down.
 
-But a real library is not a stack of independent documents, and this is where a plain tree runs out. The `→` row in the outline above is the tell: that bulletin's _Condition_ section points into a **different document** - the misfire-diagnosis procedure in a manual. AutoFix's documents reference each other constantly: the bulletin's author writes a cross-reference into a manual's diagnostic procedure, another section points at the related safety recall, an outbound URL becomes a stub document. Those are exactly the "what else applies here?" links a service advisor follows - and a tree can't hold them, because they jump between branches.
+But a real library is not a stack of independent documents, and this is where a plain tree runs out. The `→` row in the outline above points into a **different document** - the misfire-diagnosis procedure in a manual. AutoFix's documents reference each other constantly: the bulletin's author writes a cross-reference into a manual's diagnostic procedure, another section points at the related safety recall, an outbound URL becomes a stub document. Those are exactly the "what else applies here?" links a service advisor follows - and a tree can't hold them, because they jump between branches.
 
-That is the reason - and the _only_ reason that matters - to reach for a graph: keep the tree for navigation, and add the cross-document links the tree can't express.
+That is a good reason to reach for a graph: keep the tree for navigation, and add the cross-document links the tree can't express.
 
 [source,mermaid]
 ----
@@ -54,6 +55,7 @@ graph TD
     FM -->|HAS| D2((man-falcon-<br/>engine))
     D1 -->|HAS| S1((Condition))
     D1 -->|HAS| S2((Repair<br/>Procedure))
+    S1 -.-> |NEXT-SECTION| S2
     D2 -->|HAS| S3((Misfire<br/>Diagnosis))
     S1 -.->|LINKS_TO| S3
 ----
@@ -90,6 +92,29 @@ The search tool you build next ranks entry points with full-text search - chosen
 
 
 [.slide]
+== Load the library and see the shape
+
+That model is what one command builds. It loads **documents only** - the warehouse rows stay in BigQuery (you wired them up in Module 2); only the PDF library crosses into the graph here:
+
+[source,shell]
+.Parse the PDFs into the document graph
+----
+python load/load_documents.py
+----
+
+It parses the PDF library into one Library tree - 3 folders, 183 documents, 985 sections, threaded by reading order (`NEXT_SECTION`) and the documents' own cross-references (`LINKS_TO`). The document half comes from **real PDFs**; the parser is the same shape a production pipeline would run over cloud storage. It writes alongside the connections graph from Module 2 - the two halves share the sandbox without touching each other.
+
+Now look at the shape you just loaded. Run this in the sandbox on the right to walk the top of the tree - the Library, its folders, the documents inside, and their first sections:
+
+[source,cypher]
+----
+MATCH p=(:Library)-[*0..4]->() RETURN p LIMIT 10
+----
+
+That is the containment tree from the diagram, live. Part numbers and trouble codes are **not** nodes here - they live in the section text (and in BigQuery); you find them by search, next.
+
+
+[.slide]
 == Read the spec first
 
 Open `docs/outline-format.md` in your Codespace.
@@ -101,7 +126,7 @@ That file is not documentation of something that exists - **it is the spec you a
 
 Read it and ask the shape-first question: _what graph reasoning materializes this?_
 The answer - one variable-length `[:HAS*]` walk emitting flat rows the renderer assembles - is the heart of the next challenge.
-Notice what is impossible in fixed-join thinking: the tree's depth is not known in advance, so no fixed number of joins can walk it.
+The tree's depth is not known in advance, so no fixed number of joins can walk it.
 
 read::Continue to the challenge[]
 
@@ -115,6 +140,7 @@ In this lesson, you learned the first shape and the model behind it:
 * **One `HAS` type** - containment is a tree; every edge means the same thing, so trees walk as `[:HAS*]`
 * **`LINKS_TO` makes it a graph** - the cross-references the author actually wrote, jumping between branches a tree can't hold (the `→` rows)
 * **Hierarchical URIs** - any subtree is a prefix; fragments carry the full heading path, so every address is copy-pasteable
+* **The library is loaded** - `load/load_documents.py` built the document tree (183 docs, 985 sections) alongside Module 2's connections graph; you saw it live in the sandbox
 * **Shape-first** - the spec (`docs/outline-format.md`) comes before any Cypher
 
 In the next challenge, you and your agent build the outline and search tools from their specs.

--- a/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/1-documents-are-graphs/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/1-documents-are-graphs/lesson.adoc
@@ -111,7 +111,7 @@ Now look at the shape you just loaded. Run this in the sandbox on the right to w
 MATCH p=(:Library)-[*0..4]->() RETURN p LIMIT 10
 ----
 
-That is the containment tree from the diagram, live. Part numbers and trouble codes are **not** nodes here - they live in the section text (and in BigQuery); you find them by search, next.
+That is the containment tree, links, and next-sections from the diagram, live. Part numbers and trouble codes are **not** nodes here - they live in the section text (and in BigQuery); you find them by search, next.
 
 
 [.slide]

--- a/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/2-navigation-tools/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/2-navigation-tools/lesson.adoc
@@ -19,8 +19,17 @@ This completes **Building Block 1**: "The agent can navigate what's there" ✓
 
 Open `skill/scripts/outline.py`.
 The renderer - grouping, sibling sorting, dotted rows - is given; the `WIRE` query is marked `BUILD FROM SPEC`.
-Hand your agent the wire contract from `docs/outline-format.md` and review what it writes.
-The reasoning it must land on:
+This is the first query you wire, so here is the loop you will reuse for every `BUILD FROM SPEC` query: drive your agent from the spec with the neo4j-cypher-skill, and keep the answer key out of it.
+
+[source,text]
+.Wire a tool from its spec
+----
+Use the neo4j-cypher-skill and the spec in docs/outline-format.md to fill in the
+BUILD FROM SPEC query in skill/scripts/outline.py. Do not reference anything in
+solutions/ for this exercise.
+----
+
+Review what it writes - the reasoning it must land on:
 
 [source,cypher]
 .The walk that materializes a tree of unknown depth
@@ -46,6 +55,14 @@ Copy any URI from the output and drill into it: that round-trip is the shape doi
 == Build the search query
 
 Open `skill/scripts/search.py` - same deal, the fulltext call is marked `BUILD FROM SPEC`.
+
+[source,text]
+.Wire the search tool from its spec
+----
+Use the neo4j-cypher-skill and the BUILD FROM SPEC contract in skill/scripts/search.py
+to fill in its query. Do not reference anything in solutions/ for this exercise.
+----
+
 The index already exists (the pipeline created `content_search` over `Document|Section`); the query calls it, then **scopes by subtree**:
 
 [source,cypher]
@@ -77,7 +94,16 @@ Try asking your agent: "search the library for anything about engines shaking" -
 [TIP]
 .Stuck or out of sync?
 ====
-Complete versions are in `solutions/scripts/` - compare or copy, then keep moving.
+If a result looks off, have the agent check itself against the reference instead of stalling:
+
+[source,text]
+.Self-check without stalling
+----
+Compare skill/scripts/outline.py against solutions/scripts/outline.py. Report any
+mistakes and how I should adjust my prompt so I get it right myself next time.
+----
+
+As a last resort, the complete versions are in `solutions/scripts/` to copy - then keep moving.
 ====
 
 include::questions/verify.adoc[leveloffset=+1]

--- a/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/2-navigation-tools/questions/verify.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/2-navigation-tools/questions/verify.adoc
@@ -41,5 +41,5 @@ You should see 183 documents, 985 sections, and roughly 1300 links.
 **If verification fails:**
 
 * Confirm `.env` has the sandbox credentials from Module 1, then re-run the pipeline
-* If the database has stray data, clear it with `MATCH (n) DETACH DELETE n` and re-run
+* The pipeline rebuilds the document half cleanly on every run and leaves Module 2's connections graph (`:Table`/`:Column`) in place - just re-run it. Avoid a blanket `MATCH (n) DETACH DELETE n`; that would also drop the connections graph the finale needs
 ====

--- a/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/3-navigate-the-shape/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/3-navigate-the-shape/lesson.adoc
@@ -23,7 +23,6 @@ The tree answers it directly:
 ----
 python skill/scripts/outline.py technical-library/manuals/man-falcon-engine.pdf
 ----
-// TODO - Depth Needed and not currently working
 
 You should see the manual's sections in reading order, nested sub-sections, and `→` rows where its sections link out.
 Underneath, the tool runs one variable-length walk - `MATCH path = (root)-[:HAS*0..25]->(n)` - and the renderer turns path lengths into indentation.

--- a/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/module.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/module.adoc
@@ -1,7 +1,7 @@
-= Navigate What's There - Trees
+= Navigate What's There - Table of Contents
 :order: 3
 
-Keyword search over the manual portal returns 40 hits that all look right.
+Search finds what looks similar; navigation follows the structure to what you actually need — the complement that reads the table of contents before flipping through every page.
 In this module, you will read the spec for the outline shape, derive the graph reasoning it needs, and build your skill's navigation tools - then put them to work on the questions keyword search cannot answer.
 
 

--- a/asciidoc/courses/workshop-lakehouse/modules/4-surface-themes/lessons/2-detect-themes/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/4-surface-themes/lessons/2-detect-themes/lesson.adoc
@@ -30,7 +30,15 @@ Collapsing section-level edges to their owning documents needs no tree walk - th
 MATCH (d:Document {uri: split(s.uri, '#')[0]})
 ----
 
-Hand the projection spec to your agent and review the Cypher: sections' `LINKS_TO` edges, both ends collapsed to their owning `Document`, undirected, weighted by link count.
+Hand the projection spec to your agent and review the Cypher: sections' `LINKS_TO` edges, both ends collapsed to their owning `Document`, undirected, weighted by link count. Same loop as the navigation tools - drive it from the spec:
+
+[source,text]
+.Wire the themes projection from its spec
+----
+Use the neo4j-cypher-skill and the spec in docs/theme-format.md to fill in the
+BUILD FROM SPEC projection query in skill/scripts/themes.py. Do not reference
+anything in solutions/ for this exercise.
+----
 
 
 [.slide]
@@ -65,7 +73,7 @@ Note the spec's stability contract: theme numbers are assigned per run - **store
 [TIP]
 .Stuck or out of sync?
 ====
-The complete script is in `solutions/scripts/themes.py`.
+Use the same self-check loop from the outline tool: have your agent compare `skill/scripts/themes.py` against `solutions/scripts/themes.py` and tell you how to adjust your prompt. As a last resort, the complete script is there to copy - then keep moving.
 ====
 
 include::questions/verify.adoc[leveloffset=+1]

--- a/asciidoc/courses/workshop-lakehouse/summary.adoc
+++ b/asciidoc/courses/workshop-lakehouse/summary.adoc
@@ -9,6 +9,7 @@ You have learned:
 * How to surface repair themes nobody named using Leiden community detection
 * How to federate the BigQuery warehouse with the graph - crossing the boundary on the shared key (part number / trouble code), with nothing migrated
 * How to write multi-hop Cypher that crosses the document-to-table boundary
+* How to drive a coding agent to write Cypher from a spec - using the neo4j-cypher-skill instead of hand-writing queries
 * How to drive the whole workflow with a coding agent using the Neo4j CLI
 * How to port the pattern to another lakehouse or domain
 
@@ -16,6 +17,7 @@ Continue your learning with the following resources:
 
 * link:https://graphacademy.neo4j.com[GraphAcademy^] - Free online training for Neo4j
 * link:https://neo4j.com/labs/genai-ecosystem/agent-skills/[Neo4j Agent Skills^] - The skills catalog your coding agent gained from `neo4j-cli skill install`
+* link:https://graphacademy.neo4j.com/courses/cypher-fundamentals[Cypher Fundamentals^] - Read and write the Cypher your agent generated for you
 * link:https://graphacademy.neo4j.com/courses/genai-fundamentals[Neo4j and Generative AI Fundamentals^] - Learn how Neo4j and GraphRAG can support your Generative AI projects
 * link:https://graphacademy.neo4j.com/courses/gds-community-detection[Community Detection^] - Go deeper on Leiden and Louvain with Graph Data Science
 * link:https://graphacademy.neo4j.com/courses/genai-context-graphs[Context Graphs: Agent Memory with Neo4j^] - Give your agents persistent, explainable memory


### PR DESCRIPTION
## Summary
- Move the document load into Module 3 so learners see the graph populate live as they work through navigation
- Teach agent-written Cypher from a spec in the navigation-tools lesson
- Small module/lesson text updates across M1 (context/problem) and M3 (navigate-documents), plus detect-themes and summary tweaks

## Changes
- `1-context-problem/module.adoc`, `3-navigate-documents/module.adoc` — module text updates
- `3-navigate-documents/lessons/1-documents-are-graphs`, `2-navigation-tools`, `3-navigate-the-shape` — load doc into M3, agent-written Cypher from spec, verify question fix
- `2-your-environment/lesson.adoc`, `2-detect-themes/lesson.adoc`, `course.adoc`, `summary.adoc` — supporting updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)