### PR TITLE
Shapes

### DIFF
--- a/asciidoc/courses/workshop-lakehouse/course.adoc
+++ b/asciidoc/courses/workshop-lakehouse/course.adoc
@@ -4,7 +4,7 @@
 :duration: 2 hours
 :caption: Give your agent the shapes its answers need - across documents in Neo4j and a warehouse in BigQuery
 :usecase: graph-data-science-blank-sandbox
-:key-points: Agent context, Connections trees and themes, neocarta over BigQuery, Federation vs migration, Coding agents with neo4j-cli
+:key-points: Agent context, Connections outline and themes, neocarta over BigQuery, Federation vs migration, Coding agents with neo4j-cli
 
 == Course Description
 
@@ -16,7 +16,7 @@ The problem isn't caused by a bad model or bad query, but rather a lack of **con
 In this hands-on workshop, you give an agent three reusable shapes:
 
 * **Connections (Paths)** - how structured warehouse data joins and connects
-* **Table of Contents (Trees & Links)** - navigate documents
+* **Outline (Trees & Links)** - navigate documents by their table of contents
 * **Themes (Communities)** - surface patterns nobody named
 
 These shapes answer the questions a modern stack gets quietly wrong - not just the single lookups it already handles most of the time, but the *estate-level* ones: the patterns across an entire document set, what your records show happening that the documentation never covers, and how things connect across a boundary no one query spans. Each needs the agent to cover, navigate, or follow the whole structure - not retrieve a similar slice.

--- a/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/lessons/1-workshop-overview/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/lessons/1-workshop-overview/lesson.adoc
@@ -48,7 +48,7 @@ The problem is not a bad model or a bad query - it is a lack of *context*.
 The fix is to give the agent the shapes its answers need:
 
 * **Connections (Paths)** - how the warehouse tables join, in Module 2 - neocarta reads the foreign keys, so the agent follows the joins instead of guessing: the **Connection** question
-* **Table of Contents (Trees & Links)** - navigate the documents, in Module 3 - follow structure and tell "not there" from "not retrieved": the **Absence** question
+* **Outline (Trees & Links)** - the table of contents you navigate documents by, made into a graph, in Module 3 - follow structure and tell "not there" from "not retrieved": the **Absence** question
 * **Themes (Communities)** - surface patterns nobody named, in Module 4 - cover and cluster the whole library instead of sampling: the **Coverage** question
 
 And you learn a second axis: _where_ each shape should live. The connections graph is a *semantic layer* - only the warehouse's metadata (table names and foreign keys), not its rows - so the rows stay in BigQuery while the documents become graphs in Neo4j. The agent crosses between them on the keys they already share - part numbers and trouble codes.

--- a/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/lessons/1-workshop-overview/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/lessons/1-workshop-overview/lesson.adoc
@@ -51,7 +51,7 @@ The fix is to give the agent the shapes its answers need:
 * **Table of Contents (Trees & Links)** - navigate the documents, in Module 3 - follow structure and tell "not there" from "not retrieved": the **Absence** question
 * **Themes (Communities)** - surface patterns nobody named, in Module 4 - cover and cluster the whole library instead of sampling: the **Coverage** question
 
-And you learn a second axis: _where_ each shape should live. The documents and the warehouse's connections become graphs in Neo4j; the warehouse rows stay in BigQuery; and the agent crosses between them on the keys they already share - part numbers and trouble codes.
+And you learn a second axis: _where_ each shape should live. The connections graph is a *semantic layer* - only the warehouse's metadata (table names and foreign keys), not its rows - so the rows stay in BigQuery while the documents become graphs in Neo4j. The agent crosses between them on the keys they already share - part numbers and trouble codes.
 
 image::images/lakehouse-neo4j.png[The shape layer over the lakehouse: documents are parsed and ingested into a Neo4j document graph (Trees + Themes) and the warehouse's metadata into a connections graph, while the warehouse rows stay in BigQuery; the agent retrieves from the graphs directly and reads the warehouse with grounded SQL.]
 

--- a/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/lessons/2-your-environment/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/lessons/2-your-environment/lesson.adoc
@@ -37,7 +37,7 @@ While it builds (a few minutes), look at what is inside:
 [NOTE]
 .Prefer your own setup?
 ====
-Everything runs locally too: clone the repository and run `.devcontainer/post-create-local.sh` - it installs link:https://github.com/neo4j-labs/neo4j-cli[neo4j-cli^], the Python dependencies, and the agent skills the same way the Codespace does.
+Everything runs locally too: link:https://github.com/zach-blumenfeld/genai-workshop-lakehouse[clone the repository^] and run `.devcontainer/post-create-local.sh` - it installs link:https://github.com/neo4j-labs/neo4j-cli[neo4j-cli^], the Python dependencies, and the agent skills the same way the Codespace does. The script installs the Python dependencies into an isolated `.venv`, so activate it with `source .venv/bin/activate` before running any of the tool scripts.
 ====
 
 [.slide]

--- a/asciidoc/courses/workshop-lakehouse/modules/2-connections/lessons/1-connections-shape/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/2-connections/lessons/1-connections-shape/lesson.adoc
@@ -22,7 +22,7 @@ A warehouse is a set of tables wired together by foreign keys: a work order's `v
 Text2SQL does not see them as a structure - it infers joins from column names and hopes. The **connections shape** makes them explicit and traversable: an agent that can read "`work_orders` joins to `vehicles` on `vin`" writes the right join instead of guessing it.
 
 [NOTE]
-.Not "the tool can't" - "the tool guesses"
+.Why Text2SQL guesses joins
 ====
 A modern Text2SQL system _can_ write this join. The problem is reliability: on independent enterprise benchmarks, models hit a *78.57% error rate on queries touching four or more tables*footnote:falcon[Independent Text2SQL benchmarks: _Falcon: A Comprehensive Chinese Text-to-SQL Benchmark for Enterprise-Grade Evaluation_ (Luo et al., arXiv:2510.24762, 2025) reports 78.57% error on queries touching four or more tables - https://arxiv.org/abs/2510.24762; _Spider 2.0: Evaluating Language Models on Real-World Enterprise Text-to-SQL Workflows_ (arXiv:2411.07763, ICLR 2025) reports frontier models at 10-17% on real enterprise schemas - https://arxiv.org/abs/2411.07763.] - the shape of joins on any real, many-table warehouse. The connections graph does not make the join _possible_; it makes it _deterministic and auditable_ - the same correct path every time, one you can inspect.
 ====
@@ -39,24 +39,9 @@ graph LR
 //TODO: Replace above with an ERD diagram reflecting how it would normally be visualized for RDBMS.  If Metmaid isn't the right visual fit lets use another tool and place img here if we have to.
 
 [.slide]
-== neocarta reads it from the warehouse
+== Building the semantic layer
 
-You do not hand-build this graph. link:https://github.com/neo4j-labs/neocarta[neocarta^] - a Neo4j Labs library - reads a warehouse's information schema and writes the metadata graph for you:
-
-----
-(:Database)-[:HAS_SCHEMA]->(:Schema)-[:HAS_TABLE]->(:Table)-[:HAS_COLUMN]->(:Column)
-(:Column)-[:REFERENCES]->(:Column)     // one per foreign key — the join paths
-----
-
-The AutoFix warehouse lives in BigQuery with its primary and foreign keys declared. neocarta turns each foreign key into a `REFERENCES` edge - the connections shape, ready to query.
-//TODO - Note that even with out FK meta data you can infer from schema log or other info (OSI?)
-
-//TODO: Note We are using BQ now but this is soon to be integrated with DBX - reference?
-
-[.slide]
-== Migrate the map, not the territory
-
-Getting our agent to understand what shapes to use doesn't require data migration — just another layer.footnote:[This doesn't address graph query performance, which is sometimes required and does necessitate migration.]
+To solve the problem of the missing context, we need a way to give the agent these join paths, and to do it without copying the entire warehouse into Neo4j. That is what our connections graph does: it is a **semantic layer graph** that holds the join paths. Getting the agent to understand what shapes to use does not require data migration, just another layer.footnote:[This doesn't address graph query performance, which is sometimes required and does necessitate migration.]
 
 [cols="1,2,2", options="header"]
 |===
@@ -75,14 +60,29 @@ Getting our agent to understand what shapes to use doesn't require data migratio
 | Enable the agent to _query data using graph traversals and algorithms_ for *_multi-hop reasoning at the query execution level_*.
 |===
 
-For now, we just need our agent to **understand** what shapes to use and how to query it with Text2SQL. Neocarta fills this job as a semantic layer and is therfore sufficient for our learning here. For more info on Virtual Graph, see link:https://neo4j.com/product/virtual-graph/[Neo4j Virtual Graph^].
+For now, we just need our agent to **understand** what shapes to use and how to query it with Text2SQL. A **semantic layer** fills this job and is therefore sufficient for our learning here. For more info on Virtual Graph, see link:https://neo4j.com/product/virtual-graph/[Neo4j Virtual Graph^].
 
-Neocarta copies the warehouse's _metadata_ - table and column names, the foreign-key graph. It does **not** copy the rows.
+[.slide]
+== neocarta builds the semantic layer graph
+
+You do not hand-build this graph. link:https://github.com/neo4j-labs/neocarta[neocarta^] - a Neo4j Labs library - reads a warehouse's information schema and builds the semantic layer graph for you:
+
+----
+(:Database)-[:HAS_SCHEMA]->(:Schema)-[:HAS_TABLE]->(:Table)-[:HAS_COLUMN]->(:Column)
+(:Column)-[:REFERENCES]->(:Column)     // one per foreign key, the join paths
+----
+
+The AutoFix warehouse lives in BigQuery with its primary and foreign keys declared. neocarta turns each foreign key into a `REFERENCES` edge - the connections shape, ready to query.
+//TODO - Note that even with out FK meta data you can infer from schema log or other info (OSI?)
+
+//TODO: Note We are using BQ now but this is soon to be integrated with DBX - reference?
+
+neocarta copies the warehouse's _metadata_ - table and column names, the foreign-key graph - to create the semantic layer graph. It does **not** copy the rows.
 
 [NOTE]
-.The security knob
+.Sample values are pulled by default
 ====
-neocarta does pulls sample column values by default - handy for routing ("model is `Falcon`, `Heron`, or `Osprey`")
+neocarta pulls sample column values by default - handy for routing ("vehicle model is `Falcon`, `Heron`, or `Osprey`")
 ====
 //TODO: See if this can be turned off in neocarta, if not jusst be aware
 
@@ -104,8 +104,8 @@ read::Continue to the challenge[]
 In this lesson, you learned the connections shape:
 
 * **Join paths** - foreign keys made explicit, so the agent routes instead of guessing
-* **neocarta** - reads the warehouse information schema into a Neo4j metadata graph
-* **Layer vs. migrate** - the agent only needs to *understand* the shape to query with Text2SQL, so use neocarta as the semantic layer; data stays in BigQuery
+* **Semantic layer** - the connections graph is a semantic layer focused on join paths; the agent only needs to *understand* the shape to query with Text2SQL, so data stays in BigQuery
+* **neocarta** - reads the warehouse information schema and builds the semantic layer graph in Neo4j
 * **The connections MCP** - neocarta exposes the graph to your agent as schema tools
 
 In the next challenge, you run neocarta and watch your agent query the connections graph through the MCP.

--- a/asciidoc/courses/workshop-lakehouse/modules/2-connections/lessons/1-connections-shape/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/2-connections/lessons/1-connections-shape/lesson.adoc
@@ -22,7 +22,7 @@ A warehouse is a set of tables wired together by foreign keys: a work order's `v
 Text2SQL does not see them as a structure - it infers joins from column names and hopes. The **connections shape** makes them explicit and traversable: an agent that can read "`work_orders` joins to `vehicles` on `vin`" writes the right join instead of guessing it.
 
 [NOTE]
-.Why Text2SQL guesses joins
+.It can write the join - it just guesses the keys
 ====
 A modern Text2SQL system _can_ write this join. The problem is reliability: on independent enterprise benchmarks, models hit a *78.57% error rate on queries touching four or more tables*footnote:falcon[Independent Text2SQL benchmarks: _Falcon: A Comprehensive Chinese Text-to-SQL Benchmark for Enterprise-Grade Evaluation_ (Luo et al., arXiv:2510.24762, 2025) reports 78.57% error on queries touching four or more tables - https://arxiv.org/abs/2510.24762; _Spider 2.0: Evaluating Language Models on Real-World Enterprise Text-to-SQL Workflows_ (arXiv:2411.07763, ICLR 2025) reports frontier models at 10-17% on real enterprise schemas - https://arxiv.org/abs/2411.07763.] - the shape of joins on any real, many-table warehouse. The connections graph does not make the join _possible_; it makes it _deterministic and auditable_ - the same correct path every time, one you can inspect.
 ====

--- a/asciidoc/courses/workshop-lakehouse/modules/2-connections/lessons/2-build-connections/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/2-connections/lessons/2-build-connections/lesson.adoc
@@ -8,7 +8,7 @@
 [.slide.discrete]
 == Challenge
 
-Build the connections graph from BigQuery with neocarta, then watch your agent _use_ it - retrieve the warehouse schema and write correct Text2SQL. This is the same pattern the finale runs on, in miniature.
+Build the connections graph - the semantic layer graph from the previous lesson - from BigQuery with neocarta, then watch your agent _use_ it - retrieve the warehouse schema and write correct Text2SQL. This is the same pattern the finale runs on, in miniature.
 
 This completes **Building Block 1**: "The agent knows how the warehouse joins" ✓
 //TODO: is above sentence needed?
@@ -16,7 +16,7 @@ This completes **Building Block 1**: "The agent knows how the warehouse joins" �
 [.slide]
 == Run neocarta
 
-The neocarta connector reads the AutoFix warehouse's information schema from BigQuery and writes the metadata graph - tables, columns, and a `REFERENCES` edge per foreign key - into your Neo4j sandbox:
+The neocarta connector reads the AutoFix warehouse's information schema from BigQuery and writes the semantic layer graph - tables, columns, and a `REFERENCES` edge per foreign key - into your Neo4j sandbox:
 
 [source,shell]
 .Build the connections graph
@@ -99,7 +99,7 @@ TODO: Exrecises for this section
 
 You built the connections shape and put it to work:
 
-* **neocarta** - read the warehouse foreign keys from BigQuery into a metadata graph, rows untouched
+* **neocarta** - read the warehouse foreign keys from BigQuery into a semantic layer graph, rows untouched
 * **The connections MCP** - exposes that graph to your agent as schema-retrieval tools, no embeddings
 * **Agentic Text2SQL** - the agent reads the foreign keys and writes the multi-table join itself, grounded, not guessed
 * **Building Block 1**: "The agent knows how the warehouse joins" ✓

--- a/asciidoc/courses/workshop-lakehouse/modules/2-connections/module.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/2-connections/module.adoc
@@ -1,4 +1,4 @@
-= Connections - the structured shape
+= Connections - the warehouse shape
 :order: 2
 
 Sam's second wall: Text2SQL is quietly wrong on multi-hop joins. The fix is not a better model - it is giving the agent the *connections*: how the warehouse tables actually join.

--- a/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/1-documents-are-graphs/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/1-documents-are-graphs/lesson.adoc
@@ -12,7 +12,7 @@ AutoFix has a library of documents - service manuals, technical bulletins, and r
 
 The reflex move is to chunk every document, embed the chunks, and search by similarity. That hands the agent a slice that _reads_ like the query. But a slice has no address: the agent can't tell which document it came from, which section it sits in, or what comes before and after it. And the cut itself is lossy - a fixed-size chunk boundary can fall mid-procedure, and once a fact is split across two chunks at ingest, no reranker or bigger context window puts it back together.footnote:[Fixed-size chunking destroys structure _before retrieval ever runs_ - see link:https://pageindex.ai/blog/pageindex-intro[PageIndex^] on the "chunking floor."]
 
-To _navigate_ a library, an agent needs something a pile of chunks can't give it: **structure**. That structure is an **outline shape** stored in a **graph** - an index of every document in the library and how they link to each other. It is built in two steps:
+To _navigate_ a library, an agent needs something a pile of chunks can't give it: **structure**. That structure is an **outline shape** stored in a **graph** - an index of every document in the library and how they link to each other. You already know what it looks like rendered - a **table of contents**: names on the left to read, addresses on the right to jump to. The outline is the structure; the table of contents is how you (and the agent) read it. The outline is built in two steps:
 
 * **Table of contents** - the outline of a single document, so the agent can read it and jump straight to the section it needs.
 * **Library index** - how those individual documents are organized and linked into one navigable map of the whole library.

--- a/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/1-documents-are-graphs/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/1-documents-are-graphs/lesson.adoc
@@ -12,17 +12,28 @@ AutoFix has a library of documents - service manuals, technical bulletins, and r
 
 The reflex move is to chunk every document, embed the chunks, and search by similarity. That hands the agent a slice that _reads_ like the query. But a slice has no address: the agent can't tell which document it came from, which section it sits in, or what comes before and after it. And the cut itself is lossy - a fixed-size chunk boundary can fall mid-procedure, and once a fact is split across two chunks at ingest, no reranker or bigger context window puts it back together.footnote:[Fixed-size chunking destroys structure _before retrieval ever runs_ - see link:https://pageindex.ai/blog/pageindex-intro[PageIndex^] on the "chunking floor."]
 
-To _navigate_ a library, an agent needs something a pile of chunks can't give it: **structure**. So before writing a single query, we decide the shape that structure should take. The first shape is the one every well-organized document already has - a **table of contents**.
+To _navigate_ a library, an agent needs something a pile of chunks can't give it: **structure**. That structure is an **outline shape** stored in a **graph** - an index of every document in the library and how they link to each other. It is built in two steps:
+
+* **Table of contents** - the outline of a single document, so the agent can read it and jump straight to the section it needs.
+* **Library index** - how those individual documents are organized and linked into one navigable map of the whole library.
+
+We build them in that order, starting with the table of contents.
 
 
 [.slide]
 == Give the agent a table of contents
 
-A table of contents is a map: it shows what's in the library and where, and it lets you jump straight to the part you need. It's is how humans navigate large documents and libraries. Hand that same map to an agent and it can do the same thing - read the outline, reason about which entry answers the question, and open only that section. **Navigation instead of similarity.**
+A table of contents is a map of a single document: it shows what's in the document and where, and it lets you jump straight to the part you need. Its shape is a **tree** - sections nesting into sub-sections. It's how humans navigate large documents. Hand that same map to an agent and it can do the same thing - read the outline, reason about which entry answers the question, and open only that section. **Navigation instead of similarity.**
 
 This is a proven pattern, not a hunch. link:https://pageindex.ai/blog/pageindex-intro[PageIndex^] builds a hierarchical table of contents over a document and has an LLM reason _down the tree_ to the right section - no embeddings, no chunking. On FinanceBench (question-answering over real SEC filings) the approach reports **98.7% accuracy, against roughly 50% for naive vector RAG**.footnote:[The conceptual precursor is Prompt-RAG (Kang et al., link:https://arxiv.org/abs/2401.11246[arXiv:2401.11246^]): let the LLM pick headings from a document's ToC and pass those sections as context.]
 
-Here is the shape you are about to give your agent - AutoFix's library rendered as a navigable outline:
+
+[.slide]
+== Build the library from trees
+
+One document is one tree. A library is many trees. Nest them - the library contains folders, folders contain documents, documents contain sections, sections nest into sub-sections - and one containment relationship, `HAS`, walks the whole thing top-down.
+
+Here is that shape: AutoFix's entire library rendered as a single navigable outline.
 
 ----
 NAME                                                 T   URI
@@ -35,12 +46,6 @@ AutoFix Technical Library .......................... L   technical-library
 ----
 
 Names on the left for a human to read; full URIs on the right that the agent copies back into a tool to drill in or pull the text.
-
-
-[.slide]
-== One tree per document - and links across the library
-
-A single document's table of contents is a **tree**: the library contains folders, folders contain documents, documents contain sections, sections nest into sub-sections. One containment relationship, `HAS`, walks the whole thing top-down.
 
 But a real library is not a stack of independent documents, and this is where a plain tree runs out. The `→` row in the outline above points into a **different document** - the misfire-diagnosis procedure in a manual. AutoFix's documents reference each other constantly: the bulletin's author writes a cross-reference into a manual's diagnostic procedure, another section points at the related safety recall, an outbound URL becomes a stub document. Those are exactly the "what else applies here?" links a service advisor follows - and a tree can't hold them, because they jump between branches.
 
@@ -60,7 +65,7 @@ graph TD
     S1 -.->|LINKS_TO| S3
 ----
 
-So the document half of the graph is three relationships:
+So the document side of the graph is three relationships:
 
 * `(parent)-[:HAS]->(child)` - containment, the tree. Every edge means the same thing ("parent in the tree"), and the node label (Library / Folder / Document / Section) says what kind of child it is - so any walk is just `[:HAS*]`, however deep.
 * `(Section)-[:NEXT_SECTION]->(Section)` - reading order, so the agent can read a section _in context_ instead of in isolation.
@@ -102,7 +107,7 @@ That model is what one command builds. It loads **documents only** - the warehou
 python load/load_documents.py
 ----
 
-It parses the PDF library into one Library tree - 3 folders, 183 documents, 985 sections, threaded by reading order (`NEXT_SECTION`) and the documents' own cross-references (`LINKS_TO`). The document half comes from **real PDFs**; the parser is the same shape a production pipeline would run over cloud storage. It writes alongside the connections graph from Module 2 - the two halves share the sandbox without touching each other.
+It parses the PDF library into one Library tree - 3 folders, 183 documents, 985 sections, threaded by reading order (`NEXT_SECTION`) and the documents' own cross-references (`LINKS_TO`). The document half comes from **real PDFs**; the parser is the same shape a production pipeline would run over cloud storage. It writes alongside the connections graph from Module 2 - the two sides share the sandbox without touching each other.
 
 Now look at the shape you just loaded. Run this in the sandbox on the right to walk the top of the tree - the Library, its folders, the documents inside, and their first sections:
 

--- a/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/3-navigate-the-shape/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/3-navigate-the-shape/lesson.adoc
@@ -45,7 +45,7 @@ CALL db.index.fulltext.queryNodes('content_search', '"IC-2042-A"')
 YIELD node, score
 WHERE node:Section
 MATCH (doc:Document)-[:HAS*]->(node)
-RETURN DISTINCT doc.area AS type, doc.title AS document,
+RETURN DISTINCT doc.area AS type, doc.id, doc.title AS document,
        collect(node.displayName) AS sections
 ----
 

--- a/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/3-navigate-the-shape/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/3-navigate-the-shape/lesson.adoc
@@ -1,4 +1,4 @@
-= Navigate the Shape
+= Navigate the Outline
 :type: challenge
 :order: 3
 :duration: 8

--- a/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/module.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/module.adoc
@@ -1,7 +1,7 @@
-= Navigate What's There - Table of Contents
+= The Outline Shape - your documents' table of contents
 :order: 3
 
-Search finds what looks similar; navigation follows the structure to what you actually need — the complement that reads the table of contents before flipping through every page.
+Search finds what looks similar; navigation follows the structure to what you actually need - the complement that reads the table of contents before flipping through every page.
 In this module, you will read the spec for the outline shape, derive the graph reasoning it needs, and build your skill's navigation tools - then put them to work on the questions keyword search cannot answer.
 
 

--- a/asciidoc/courses/workshop-lakehouse/modules/4-surface-themes/lessons/1-communities/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/4-surface-themes/lessons/1-communities/lesson.adoc
@@ -36,6 +36,10 @@ Those shared link targets pull documents together: two documents that both link 
 **Community detection** algorithms find those clusters automatically.
 You will use **Leiden**, a link:https://neo4j.com/docs/graph-data-science/current/[Graph Data Science (GDS)^] algorithm that assigns each node a community ID so that links inside communities are dense and links between them are sparse.
 
+Before Leiden can run, GDS needs a **projection** - a lightweight in-memory copy of just the nodes and relationships you want to analyze.
+You define which nodes and edges to include, and GDS loads them into memory for the algorithm.
+In the next challenge, you will write the projection query that feeds Leiden the document-level graph.
+
 
 [.slide]
 == Why these clusters mean something

--- a/asciidoc/courses/workshop-lakehouse/modules/4-surface-themes/lessons/1-communities/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/4-surface-themes/lessons/1-communities/lesson.adoc
@@ -59,6 +59,8 @@ That is the second shape: **patterns nobody named**.
 [.slide]
 == Why an agent needs themes
 
+Each community Leiden finds is one of those themes - a repair topic assembled from the links, not labeled by anyone. That is exactly the structure an agent needs.
+
 Without themes, an agent answering _"what are the common patterns across our bulletins and recalls?"_ has to read everything - and blows past its context window.
 
 With themes, the agent gets a small, structured view: a handful of evidence blocks, each with its member documents and the shared link targets that define it.

--- a/asciidoc/courses/workshop-lakehouse/modules/4-surface-themes/lessons/1-communities/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/4-surface-themes/lessons/1-communities/lesson.adoc
@@ -100,6 +100,8 @@ T3  16 docs (9%) · tightly interlinked
 
 Read it as evidence, not labels: the `top shared targets` and member titles are what name each theme - _electrical / CAN-bus_, _front brakes_, _high-pressure fuel_ - and each `links into T<j>` row is a handle into how two themes connect.
 
+That `tightly interlinked` tag is the theme's _cohesion_, measured by a metric called **conductance** - how few of a cluster's links escape to other themes. The fewer that cross out, the more self-contained the theme, so the renderer shows cohesion as a word rather than a raw number.
+
 The spec for that view is `docs/theme-format.md` - read it before the challenge, the same way you read the outline spec.
 
 
@@ -113,6 +115,7 @@ In this lesson, you learned the second shape:
 
 * **Community** - a group of nodes more densely connected internally than externally
 * **Leiden** - the Graph Data Science (GDS) algorithm you will run to assign community IDs
+* **Conductance** - a metric for how few of a cluster's links escape to other themes; it backs the cohesion word (like `tightly interlinked`) shown per theme
 * **Why it works here** - shared cross-reference links make clusters correspond to real repair themes, not noise
 
 In the next challenge, you will project the document graph and run Leiden yourself.

--- a/asciidoc/courses/workshop-lakehouse/modules/4-surface-themes/lessons/2-detect-themes/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/4-surface-themes/lessons/2-detect-themes/lesson.adoc
@@ -19,18 +19,26 @@ This completes **Building Block 2**: "Themes nobody named exist as data" ✓
 
 The library has no part or code entity nodes - documents are tied together purely by their cross-reference links.
 The Falcon electrical manual and the BCM communication bulletin both link to the CAN-bus diagnosis procedure - they are about the same thing.
-The spec's key move: **collapse every section link to its owning document**.
-Project a document-level graph, and two documents that converge on the same targets land in the same neighborhood - close enough to cluster.
+The spec's key move: **replace every section-level link with a link between the documents that own those sections** - in graph terms, this is called _collapsing_ edges up to a parent node.
+Build that document-level graph, and two documents that both point at the same targets become neighbors - close enough for the clustering algorithm to group them into a theme.
 
-Collapsing section-level edges to their owning documents needs no tree walk - the URIs already encode ownership:
+Collapsing section-level edges to their owning documents needs no tree walk - the URIs already encode ownership.
+Section URIs use a `#` fragment identifier to separate the document path from the section anchor.
+For example, `technical-library/manuals/falcon-electrical#can-bus-diagnosis` belongs to the document `technical-library/manuals/falcon-electrical`.
+Splitting on `#` and taking the first element is all the lookup needs:
 
 [source,cypher]
-.Ownership is a string operation on hierarchical URIs
+.Example fragment - `s` is a Section node already matched in the outer query
 ----
+// s is a :Section node already in scope
 MATCH (d:Document {uri: split(s.uri, '#')[0]})
 ----
 
-Hand the projection spec to your agent and review the Cypher: sections' `LINKS_TO` edges, both ends collapsed to their owning `Document`, undirected, weighted by link count. Same loop as the navigation tools - drive it from the spec.  In this case, we also include the `neo4j-gds-skill` as Leiden is a Graph Data Science (GDS) algorithm.
+Hand the projection spec to your agent and review the Cypher it generates.
+The query takes every `LINKS_TO` relationship between sections and lifts both endpoints to their owning `Document` - the same collapse you just saw with the URI split.
+The resulting graph is **undirected** (only the connection matters, not which document linked first) and **weighted** by how many links two documents share - the more shared targets, the stronger the edge between them.
+Same loop as the navigation tools - drive it from the spec.
+In this case, we also include the `neo4j-gds-skill` as Leiden is a Graph Data Science (GDS) algorithm.
 
 [source,text]
 .Wire the themes projection from its spec

--- a/asciidoc/courses/workshop-lakehouse/modules/4-surface-themes/lessons/2-detect-themes/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/4-surface-themes/lessons/2-detect-themes/lesson.adoc
@@ -51,8 +51,17 @@ anything in solutions/ for this exercise.
 [.slide]
 == Run the pipeline
 
-The rest of the script is given and runs the spec's pipeline: Leiden **mutate** → per-community conductance (the cohesion words) → write `themeId` back → renderer queries → drop the projection.
-Mutate-before-write matters: the conductance metric reads `themeId` from the in-memory projection, which never sees database writes.
+The rest of the script is given. It runs the spec's pipeline as a chain of GDS steps:
+
+. **Leiden (mutate mode)** - finds the communities and tags each document with a `themeId`, written into the *in-memory projection* (GDS's working copy of the graph), not the database.
+. **Per-community conductance** - measures how cohesive each theme is; the renderer turns this into the cohesion words you see in the output (for example, `tightly interlinked`), not a raw number.
+. **Write `themeId` back** - copies the tag from the projection into the Neo4j database so ordinary queries can read it.
+. **Renderer queries** - read the themes back from the database to build the output.
+. **Drop the projection** - release the in-memory working copy.
+
+GDS can put an algorithm's results in two separate places: the in-memory projection or the database.
+Conductance reads `themeId` from the projection, so Leiden has to run in **mutate** mode - which fills the projection - *before* the write step.
+A plain write would only update the database, which the projection never sees.
 
 [source,shell]
 ----

--- a/asciidoc/courses/workshop-lakehouse/modules/4-surface-themes/lessons/3-themes-for-agents/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/4-surface-themes/lessons/3-themes-for-agents/lesson.adoc
@@ -8,8 +8,9 @@
 [.slide.discrete]
 == Introduction
 
-Your themes tool prints evidence blocks, not answers.
-That is deliberate - and it is the part of the shape that makes agent decisions trustworthy.
+In the last challenge you built the themes tool. Run it and notice what it does _not_ do: it never tells you a theme is "brakes" or "electrical." Each block hands you the evidence - the shared link targets and member titles - and leaves the naming to you.
+
+That restraint is deliberate, and it is the part of the shape that makes an agent's decisions trustworthy.
 
 In this lesson, you will read the blocks the way an agent does, name the themes yourself, and see what the view unlocks for Morgan's operations questions.
 
@@ -53,7 +54,7 @@ With themes as data, operations questions become one look:
 * **Where is documentation thin?** A theme held together by strong shared targets but few member documents is a training-material gap
 * **Where does a new bulletin belong?** Its cross-reference links connect it to an existing theme the moment it is loaded - no manual tagging
 
-And in the finale, the warehouse joins the reasoning: "which theme generates the most comebacks?" becomes one more hop.
+Those three answers come from the documents alone. In the finale, the agent joins the warehouse - the shop's repair records - onto these same themes. Because every document already carries its theme, an outcome question like _"which theme generates the most comebacks?"_ (jobs the customer brought back) becomes one more hop: group the repair records by theme.
 
 read::Continue[]
 

--- a/asciidoc/courses/workshop-lakehouse/modules/4-surface-themes/module.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/4-surface-themes/module.adoc
@@ -1,4 +1,4 @@
-= Surface Themes - Communities
+= Themes - the pattern shape
 :order: 4
 
 Nobody at AutoFix maintains a list of "repair themes" - but the themes are in the data, waiting to be found.

--- a/asciidoc/courses/workshop-lakehouse/modules/6-put-it-together/lessons/1-more-than-one-shape/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/6-put-it-together/lessons/1-more-than-one-shape/lesson.adoc
@@ -7,7 +7,7 @@
 [.slide.discrete]
 == Introduction
 
-You have built all three shapes - trees and themes over the documents, connections over the warehouse. The finale is the point of all of it: answering the questions you set out to answer back in Module 1.
+You have built all three shapes - outline and themes over the documents, connections over the warehouse. The finale is the point of all of it: answering the questions you set out to answer back in Module 1.
 
 Those questions do not fall to a single shape. This short lesson is the warm-up - Dani's own question - where you see why, before the estate questions in the next challenge.
 
@@ -17,7 +17,7 @@ Those questions do not fall to a single shape. This short lesson is the warm-up 
 
 Take Dani's question: _what fixed `P0301` on cars like this?_ No single shape gets you there:
 
-* the **documents** name the candidates - the bulletins that mention the code, and the parts they call out (your trees and search tools)
+* the **documents** name the candidates - the bulletins that mention the code, and the parts they call out (your outline and search tools)
 * the **warehouse** says which of those candidates actually held up - how often each was used, how often the car came back (the connections shape and the Text2SQL it grounds)
 
 The agent reaches for both and the answer falls out: the parts the documents name, ranked by what the warehouse shows really worked.

--- a/asciidoc/courses/workshop-lakehouse/modules/6-put-it-together/lessons/2-estate-questions/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/6-put-it-together/lessons/2-estate-questions/lesson.adoc
@@ -45,7 +45,7 @@ and the actual problems in the field? What documentation is missing, and what
 documentation isn't used?
 ----
 
-A similarity tool _cannot_ answer this honestly. Asked what is undocumented, it returns the nearest-looking sections and concludes the codes are "documented, just buried" - a confident, wrong claim, because similarity always returns *something* and can never prove absence. The tree shape enumerates: it walks every document and reports the codes with zero hits.
+A similarity tool _cannot_ answer this honestly. Asked what is undocumented, it returns the nearest-looking sections and concludes the codes are "documented, just buried" - a confident, wrong claim, because similarity always returns *something* and can never prove absence. The outline shape enumerates: it walks every document and reports the codes with zero hits.
 
 [TIP]
 .Verify it in the sandbox - the query is the proof

--- a/asciidoc/courses/workshop-lakehouse/modules/6-put-it-together/lessons/2-estate-questions/questions/2-undocumented-codes.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/6-put-it-together/lessons/2-estate-questions/questions/2-undocumented-codes.adoc
@@ -21,5 +21,5 @@ The correct answer is **P0335 and P0340** - the crankshaft and camshaft position
 
 Both are high-comeback codes out in the field, yet not one of the library's documents mentions either - the sandbox query returns zero hits for both. The other options are all well documented: the misfire codes anchor the ignition-coil bulletins, `P0420` has its catalyst sections, and `U0121` appears in the ABS material.
 
-This is the question similarity retrieval gets confidently wrong. Asked what is undocumented, it returns the nearest-looking sections and reports the codes as "documented, just buried." It can never prove absence, because it always returns *something*. Walking the whole document structure - the tree shape - is what lets the agent say, truthfully, "there is nothing here."
+This is the question similarity retrieval gets confidently wrong. Asked what is undocumented, it returns the nearest-looking sections and reports the codes as "documented, just buried." It can never prove absence, because it always returns *something*. Walking the whole document structure - the outline shape - is what lets the agent say, truthfully, "there is nothing here."
 ====

--- a/asciidoc/courses/workshop-lakehouse/modules/7-wrap-up/lessons/1-port-the-pattern/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/7-wrap-up/lessons/1-port-the-pattern/lesson.adoc
@@ -22,7 +22,7 @@ Each shape is sourced once and then never cares where it came from:
 |===
 | Shape | What changes when you move platform
 | **Connections** | The neocarta connector: swap BigQuery for Snowflake, Databricks, or any source with declared keys - same metadata graph out
-| **Trees / Themes** | The document parser's input path (cloud storage); the graph and GDS are unchanged
+| **Outline / Themes** | The document parser's input path (cloud storage); the graph and GDS are unchanged
 | **The estate answers** | The SQL dialect your agent writes when it federates; the join paths still come from the connections graph
 |===
 
@@ -34,7 +34,7 @@ Nothing in your skill is bound to BigQuery. Point the connector and the parser a
 
 The sharper takeaway is not a shape - it is *where each shape should live*:
 
-* **Derive a graph** where you own the data or nothing else structures it - the documents (trees, themes).
+* **Derive a graph** where you own the data or nothing else structures it - the documents (outline, themes).
 * **Federate** where a system of record already owns the rows - the warehouse. Migrate only its metadata (the connections graph); query the rows in place.
 
 That rule is what keeps the pattern honest at scale: you get graph reasoning where it pays, without copying a warehouse you would only have to keep in sync.
@@ -59,7 +59,7 @@ The questions port too: "what does the documentation say applies to _this_ asset
 You built it already - the skill is the stack:
 
 * **Connections** → the neocarta MCP: grounded SQL routing where Text2SQL guesses
-* **Trees** → your navigation tools: grounded browsing - and proving what is *not* there - instead of similarity guessing
+* **Outline** → your navigation tools: grounded browsing - and proving what is *not* there - instead of similarity guessing
 * **Themes** → your theme cards: the whole estate covered and clustered in one prompt-sized view
 * **Shapes together** → the finale's move: ground in the document shapes, then read the live warehouse the connections shape routes - one answer, nothing copied
 
@@ -85,6 +85,6 @@ In this lesson, you saw how the pattern ports:
 
 * **Swap the source** - the shapes are platform-agnostic; neocarta and the parser take a new source
 * **Derive vs. federate** - the portable decision: graph what you own, federate what a warehouse owns
-* **Agent stack** - connections, trees, themes, and federation become tools alongside vector search
+* **Agent stack** - connections, outline, themes, and federation become tools alongside vector search
 
 One knowledge check to go.

--- a/asciidoc/courses/workshop-lakehouse/modules/7-wrap-up/lessons/2-knowledge-check/questions/02-tree-shape.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/7-wrap-up/lessons/2-knowledge-check/questions/02-tree-shape.adoc
@@ -1,5 +1,5 @@
 [.question]
-= The Tree Shape
+= The Outline Shape
 
 What does the `(Library)-[:HAS*]->(Section)` containment tree give an agent that keyword or vector search cannot?
 


### PR DESCRIPTION
## What

  Standardizes how the document shape is named throughout the workshop. The
  course had drifted across three labels for the same thing — "Table of Contents",
  "Trees", and "Outline". This settles on **Outline** as the shape name and
  clarifies its relationship to the table of contents.

  ## Why
  
  The slide deck names the three shapes cleanly (Table of Contents / Themes /
  Connections), but the course text used a fourth name and mixed the others, so
  the three-shape spine was hard to follow. A student could be taught "outline
  shape" and then quizzed on "the tree shape" — friction that obscured the pattern.


## Outline and ToC

 Rather than collapsing the two terms, the workshop now relates them explicitly:
  the **outline** is the structure stored in the graph, and the **table of
  contents** is how that structure is read once rendered.