### PR TITLE
lakehouse-workshop: M7 cleanup, M2 environment-setup hardening, and grammar sweep

### DIFF
--- a/asciidoc/courses/workshop-lakehouse/course.adoc
+++ b/asciidoc/courses/workshop-lakehouse/course.adoc
@@ -53,6 +53,6 @@ For the hands-on path you will need a coding agent (this workshop assumes Claude
 [.includes]
 == This workshop includes
 
-* [lessons]#11 lessons#
+* [lessons]#15 lessons#
 * [challenges]#5 hands-on challenges#
 * [quizes]#1 knowledge check#

--- a/asciidoc/courses/workshop-lakehouse/course.adoc
+++ b/asciidoc/courses/workshop-lakehouse/course.adoc
@@ -53,6 +53,6 @@ For the hands-on path you will need a coding agent (this workshop assumes Claude
 [.includes]
 == This workshop includes
 
-* [lessons]#15 lessons#
+* [lessons]#17 lessons#
 * [challenges]#5 hands-on challenges#
 * [quizes]#1 knowledge check#

--- a/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/lessons/2-your-environment/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/lessons/2-your-environment/lesson.adoc
@@ -41,6 +41,22 @@ Everything runs locally too: link:https://github.com/zach-blumenfeld/genai-works
 ====
 
 [.slide]
+== Anthropic and BigQuery credentials
+Once the `.env` file appears you will need to fill in the following.  Instructors may supply these to you.
+[source,subs="verbatim,attributes"]
+.Additional credentials (.env)
+----
+# Claude Code auth: leave blank to authenticate with your own subscription
+ANTHROPIC_API_KEY=
+
+# BigQuery auth: paste the one-line read-only key
+# (If you leave this blank, your own `gcloud auth application-default login` is used.)
+BIGQUERY_SA_KEY_B64=
+----
+
+
+
+[.slide]
 == Connect to both halves
 
 GraphAcademy has provisioned a **Neo4j sandbox** for you (with the Graph Data Science library you will use in Module 4). Paste its credentials into the `.env` file in your Codespace:
@@ -56,13 +72,6 @@ NEO4J_DATABASE={instance-database}
 
 The **BigQuery warehouse** is already wired up: your `.env` ships with `GCP_PROJECT_ID` and `BIGQUERY_DATASET_ID` pointing at the workshop's read-only AutoFix dataset. You never write to it - you only read, and only its metadata crosses into the graph.
 
-[NOTE]
-.Claude access
-====
-If you are signed in to Claude Code, you are done.
-Otherwise set `ANTHROPIC_API_KEY` in the same `.env` file - use the key provided in the workshop, or create your own at link:https://console.anthropic.com[console.anthropic.com^].
-====
-
 
 [.slide]
 == Your sandbox starts empty
@@ -73,7 +82,52 @@ Your sandbox is empty for now. You build the **connections** graph in the next m
 [.slide]
 == Meet your agent
 
-Start your coding agent in the repository root and confirm it can reach your sandbox:
+Open a new bash terminal and start your coding agent in the repository root.
+
+[source,shell]
+.Start claude
+----
+claude
+----
+
+You should be prompted for an anthropic key. Select yes.
+
+[source,shell]
+.Start claude
+----
+  Detected a custom API key in your environment
+
+  ANTHROPIC_API_KEY: sk-ant-...AAA
+
+  Do you want to use this API key?
+
+  ❯ 1. Yes
+    2. No (recommended)
+
+  Enter to confirm · Esc to cancel
+----
+
+
+If you don’t get that prompt, or accidentally select no, open a new bash window and run the below
+
+[source,shell]
+.Restart claude
+----
+# Only run in codespace not your personal!
+rm -f ~/.claude.json
+claude
+----
+
+You should also get a menu for selecting MCP servers, select yes/all.  If you accidently select the wrong option, run ther below and repeat.
+
+[source,shell]
+.Reset claude mcp
+----
+claude mcp reset-project-choices
+----
+
+
+Confirm your agent can reach your sandbox:
 
 [source,shell]
 .Smoke test

--- a/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/lessons/2-your-environment/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/lessons/2-your-environment/lesson.adoc
@@ -42,7 +42,7 @@ Everything runs locally too: link:https://github.com/zach-blumenfeld/genai-works
 
 [.slide]
 == Anthropic and BigQuery credentials
-Once the `.env` file appears you will need to fill in the following.  Instructors may supply these to you.
+Once the `.env` file appears you will need to fill in the following. Instructors may supply these to you.
 [source,subs="verbatim,attributes"]
 .Additional credentials (.env)
 ----
@@ -90,10 +90,10 @@ Open a new bash terminal and start your coding agent in the repository root.
 claude
 ----
 
-You should be prompted for an anthropic key. Select yes.
+You should be prompted for an Anthropic key. Select yes.
 
-[source,shell]
-.Start claude
+[source,text]
+.The prompt you should see
 ----
   Detected a custom API key in your environment
 
@@ -108,17 +108,17 @@ You should be prompted for an anthropic key. Select yes.
 ----
 
 
-If you don’t get that prompt, or accidentally select no, open a new bash window and run the below
+If you don't get that prompt, or accidentally select no, open a new bash window and run the command below.
 
 [source,shell]
 .Restart claude
 ----
-# Only run in codespace not your personal!
+# Only run in codespace, not your personal!
 rm -f ~/.claude.json
 claude
 ----
 
-You should also get a menu for selecting MCP servers, select yes/all.  If you accidently select the wrong option, run ther below and repeat.
+You should also get a menu for selecting MCP servers; select yes/all. If you accidentally select the wrong option, run the command below and repeat.
 
 [source,shell]
 .Reset claude mcp

--- a/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/module.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/module.adoc
@@ -11,7 +11,7 @@ By the end of this module, you will:
 * Name the three graph shapes this workshop builds: trees, communities, and paths
 * Have a running Codespace, a loaded graph, and a coding agent connected to both
 
-// TODO: CLI exists - consider mentioning here.  we do't have it integrated but that is fine
+// TODO: Neocarta CLI exists - consider mentioning here.  we do't have it integrated but that is fine
 
 // TODO: Pin Neocarta version to keep things from breaking in the import and MCP server
 

--- a/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/module.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/module.adoc
@@ -1,13 +1,13 @@
 = The Context Problem
 :order: 1
 
-AutoFix Group has every answer a technician needs - scattered across PDFs and Delta tables that don't talk to each other.
+AutoFix Group has every answer a technician needs - scattered across PDFs and BigQuery tables that don't talk to each other.
 In this module, you will meet the scenario, see why the obvious agent build fails in three distinct ways, and tour the environment you will use to fix it.
 
 
 By the end of this module, you will:
 
-* Describe the three-layer wall: vector search returns the right meaning in the wrong shape, Text2SQL is quietly wrong on multi-hop joins, and neither crosses the document-to-table boundary
+* Describe the three questions that break a modern stack - each one a different missing shape: vector search samples and cannot prove what is missing, Text2SQL guesses joins as the tables multiply, and neither covers the whole estate
 * Name the three graph shapes this workshop builds: trees, communities, and paths
 * Have a running Codespace, a loaded graph, and a coding agent connected to both
 

--- a/asciidoc/courses/workshop-lakehouse/modules/2-connections/lessons/2-build-connections/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/2-connections/lessons/2-build-connections/lesson.adoc
@@ -32,6 +32,13 @@ Connections graph ready: 6 tables, 5 REFERENCES (join paths).
 
 Click **Check Database** at the bottom of this lesson to verify the graph is in place.
 
+To see the whole connections graph, run the below:
+
+[source,cypher]
+----
+MATCH p=(:Database)-[*]->()
+RETURN p
+----
 
 [.slide]
 == Hand the graph to your agent

--- a/asciidoc/courses/workshop-lakehouse/modules/2-connections/lessons/2-build-connections/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/2-connections/lessons/2-build-connections/lesson.adoc
@@ -11,7 +11,7 @@
 Build the connections graph - the semantic layer graph from the previous lesson - from BigQuery with neocarta, then watch your agent _use_ it - retrieve the warehouse schema and write correct Text2SQL. This is the same pattern the finale runs on, in miniature.
 
 This completes **Building Block 1**: "The agent knows how the warehouse joins" ✓
-//TODO: is above sentence needed?
+// TODO: is above sentence needed?
 
 [.slide]
 == Run neocarta
@@ -23,7 +23,7 @@ The neocarta connector reads the AutoFix warehouse's information schema from Big
 ----
 python load/build_connections.py
 ----
-//TODO - consider code blco kwith  ocmmand here?  it is optional
+
 It reports the result:
 
 ----
@@ -39,14 +39,14 @@ Click **Check Database** at the bottom of this lesson to verify the graph is in 
 neocarta ships an **MCP server** that exposes it to your agent as tools. It is already wired in `.mcp.json` as the `connections` server. Reload your agent so it picks the server up, and approve it when prompted.
 
 The server gives your agent five tools:
-//TODO - this says 5 but I count 4 and we need to verify
+
 * `get_full_metadata_schema` - every table with its columns, types, example values, and **foreign-key references**
 * `list_schemas` and `list_tables_by_schema` - the catalog
 * `get_context_by_table_full_text_search` and the column variant - find the right tables by keyword
 
 This is how the agent reads the connections shape at runtime.
 
-//TODO - Below example would be better if contrasted against neocarta case.  do both ways and dem onstrate difference.
+// TODO - Below example would be better if contrasted against neocarta case.  do both ways and dem onstrate difference.
 
 [.slide]
 == Ask a question that needs a four-table join

--- a/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/1-documents-are-graphs/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/1-documents-are-graphs/lesson.adoc
@@ -113,7 +113,7 @@ Now look at the shape you just loaded. Run this in the sandbox on the right to w
 
 [source,cypher]
 ----
-MATCH p=(:Library)-[*0..4]->() RETURN p LIMIT 10
+MATCH p=(:Library)-[*0..4]->() RETURN p LIMIT 50
 ----
 
 That is the containment tree, links, and next-sections from the diagram, live. Part numbers and trouble codes are **not** nodes here - they live in the section text (and in BigQuery); you find them by search, next.

--- a/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/2-navigation-tools/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/2-navigation-tools/lesson.adoc
@@ -31,7 +31,7 @@ solutions/ for this exercise.
 
 Review what it writes - the reasoning it must land on:
 
-[source,cypher]
+[source,cypher,role=norun]
 .The walk that materializes a tree of unknown depth
 ----
 MATCH path = (root)-[:HAS*0..25]->(n)
@@ -65,7 +65,7 @@ to fill in its query. Do not reference anything in solutions/ for this exercise.
 
 The index already exists (the pipeline created `content_search` over `Document|Section`); the query calls it, then **scopes by subtree**:
 
-[source,cypher]
+[source,cypher,role=norun]
 .The index ranks, the graph scopes
 ----
 CALL db.index.fulltext.queryNodes('content_search', $lucene)

--- a/asciidoc/courses/workshop-lakehouse/modules/4-surface-themes/lessons/2-detect-themes/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/4-surface-themes/lessons/2-detect-themes/lesson.adoc
@@ -27,7 +27,7 @@ Section URIs use a `#` fragment identifier to separate the document path from th
 For example, `technical-library/manuals/falcon-electrical#can-bus-diagnosis` belongs to the document `technical-library/manuals/falcon-electrical`.
 Splitting on `#` and taking the first element is all the lookup needs:
 
-[source,cypher]
+[source,cypher,role=norun]
 .Example fragment - `s` is a Section node already matched in the outer query
 ----
 // s is a :Section node already in scope

--- a/asciidoc/courses/workshop-lakehouse/modules/6-put-it-together/lessons/2-estate-questions/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/6-put-it-together/lessons/2-estate-questions/lesson.adoc
@@ -100,5 +100,3 @@ The agent answered the estate questions by putting the shapes together:
 * **Absence** - the document graph proved `P0335`/`P0340` have zero documentation, a negative similarity cannot prove
 * **Coverage** - themes clustered *all* 112 notices into their recurring failure modes; similarity would have sampled a handful and missed the rest
 * **Connection at scale** - the connections shape keeps Text2SQL honest on warehouses too large to fit in a prompt
-
-In the final module: what it takes to run this pattern on your own lakehouse.

--- a/asciidoc/courses/workshop-lakehouse/modules/7-wrap-up/lessons/1-port-the-pattern/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/7-wrap-up/lessons/1-port-the-pattern/lesson.adoc
@@ -8,7 +8,7 @@
 == Introduction
 
 You built three shapes on one fictional repair chain.
-None of them depend on auto repair - or on any one warehouse.
+The shapes however do not depend on auto repair - or on any one warehouse.
 
 In this lesson, you will see how to port the shapes to your own lakehouse, and the decision that travels with them: derive versus federate.
 
@@ -21,21 +21,19 @@ Each shape is sourced once and then never cares where it came from:
 [cols="1,2", options="header"]
 |===
 | Shape | What changes when you move platform
-| **Connections** | The neocarta connector: swap BigQuery for Snowflake, Databricks, or any source with declared keys - same metadata graph out
-| **Trees / Themes** | The document parser's input path (cloud storage); the graph and GDS are unchanged
+| **Connections** | neocarta can connect to more than just BigQuery.  This is a growing list so see https://github.com/neo4j-labs/neocarta[the GitHub repo^] for the full list
+| **Tables of Contents / Themes** | The document parser's input path  and link and containment parsing format; the graph and GDS are unchanged
 | **The estate answers** | The SQL dialect your agent writes when it federates; the join paths still come from the connections graph
 |===
-
-Nothing in your skill is bound to BigQuery. Point the connector and the parser at your own sources and the same skill - playbook, tools, policy - runs on your data.
 
 
 [.slide]
 == The decision that travels: derive vs. federate
 
-The sharper takeaway is not a shape - it is *where each shape should live*:
+It's not just shapes, but also *where each shape should live*:
 
-* **Derive a graph** where you own the data or nothing else structures it - the documents (trees, themes).
-* **Federate** where a system of record already owns the rows - the warehouse. Migrate only its metadata (the connections graph); query the rows in place.
+* **ETL into a graph** where you own the data or nothing else structures it - the documents (tables of contents, themes).
+* **Federate** where a system of record already owns the rows - the warehouse. Migrate only its metadata (the connections graph); query the rows in place if possible.
 
 That rule is what keeps the pattern honest at scale: you get graph reasoning where it pays, without copying a warehouse you would only have to keep in sync.
 
@@ -59,13 +57,11 @@ The questions port too: "what does the documentation say applies to _this_ asset
 You built it already - the skill is the stack:
 
 * **Connections** → the neocarta MCP: grounded SQL routing where Text2SQL guesses
-* **Trees** → your navigation tools: grounded browsing - and proving what is *not* there - instead of similarity guessing
+* **Tables of Contents** → your navigation tools: grounded browsing - and proving what is and is not there - instead of similarity guessing
 * **Themes** → your theme cards: the whole estate covered and clustered in one prompt-sized view
 * **Shapes together** → the finale's move: ground in the document shapes, then read the live warehouse the connections shape routes - one answer, nothing copied
 
 Vector search still has a seat - "find me a passage about X" - and works better here, because every hit carries its tree position and theme as context.
-When a platform without a shell needs your tools, wrap the same scripts in whatever interop standard it speaks; today that is MCP, and the scripts do not change.
-
 
 [.slide]
 == Keep building
@@ -85,6 +81,6 @@ In this lesson, you saw how the pattern ports:
 
 * **Swap the source** - the shapes are platform-agnostic; neocarta and the parser take a new source
 * **Derive vs. federate** - the portable decision: graph what you own, federate what a warehouse owns
-* **Agent stack** - connections, trees, themes, and federation become tools alongside vector search
+* **Agent stack** - connections, tables of contents, themes, and federation become tools alongside vector search
 
 One knowledge check to go.

--- a/asciidoc/courses/workshop-lakehouse/modules/7-wrap-up/lessons/1-port-the-pattern/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/7-wrap-up/lessons/1-port-the-pattern/lesson.adoc
@@ -8,7 +8,7 @@
 == Introduction
 
 You built three shapes on one fictional repair chain.
-The shapes however do not depend on auto repair - or on any one warehouse.
+The shapes, however, do not depend on auto repair - or on any one warehouse.
 
 In this lesson, you will see how to port the shapes to your own lakehouse, and the decision that travels with them: derive versus federate.
 
@@ -21,8 +21,8 @@ Each shape is sourced once and then never cares where it came from:
 [cols="1,2", options="header"]
 |===
 | Shape | What changes when you move platform
-| **Connections** | neocarta can connect to more than just BigQuery.  This is a growing list so see https://github.com/neo4j-labs/neocarta[the GitHub repo^] for the full list
-| **Tables of Contents / Themes** | The document parser's input path  and link and containment parsing format; the graph and GDS are unchanged
+| **Connections** | neocarta can connect to more than just BigQuery. This is a growing list, so see https://github.com/neo4j-labs/neocarta[the GitHub repo^] for the full list
+| **Tables of Contents / Themes** | The document parser's input path, plus the link and containment parsing format; the graph and GDS are unchanged
 | **The estate answers** | The SQL dialect your agent writes when it federates; the join paths still come from the connections graph
 |===
 

--- a/asciidoc/courses/workshop-lakehouse/modules/7-wrap-up/lessons/2-knowledge-check/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/7-wrap-up/lessons/2-knowledge-check/lesson.adoc
@@ -29,7 +29,6 @@ You've successfully:
 * Built a navigable document tree from parsed PDFs with shared-key links
 * Surfaced repair themes with Leiden community detection
 * Federated the BigQuery warehouse with the graph, with nothing migrated
-* Written multi-hop Cypher that crosses the document-to-table boundary
 * Seen how to port the pattern to your own lakehouse and agents
 
 **Continue learning:**

--- a/asciidoc/courses/workshop-lakehouse/modules/7-wrap-up/lessons/2-knowledge-check/questions/01-context-problem.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/7-wrap-up/lessons/2-knowledge-check/questions/01-context-problem.adoc
@@ -1,11 +1,11 @@
 [.question]
 = The Context Problem
 
-Sam's vector search returned passages that were semantically similar to the technician's question, but the copilot still gave unreliable answers.
-What is the core reason?
+Sam's vector search returned passages that were semantically similar to the technician's question, but it didn't retrieve critical linked documents and sources, resulting in the copilot providing an unreliable response.
+Which of the below is a good hypothesis to examine first?
 
 - [ ] A. The embedding model was too small
-- [x] B. The answer needs a connected set of documents and records, not a pile of similar paragraphs
+- [x] B. The answer needs a connected set of documents and records - not just chunked passages 
 - [ ] C. Vector search cannot index PDF files
 - [ ] D. The PDFs were not chunked at the right size
 

--- a/asciidoc/courses/workshop-lakehouse/modules/7-wrap-up/lessons/2-knowledge-check/questions/01-context-problem.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/7-wrap-up/lessons/2-knowledge-check/questions/01-context-problem.adoc
@@ -5,7 +5,7 @@ Sam's vector search returned passages that were semantically similar to the tech
 Which of the below is a good hypothesis to examine first?
 
 - [ ] A. The embedding model was too small
-- [x] B. The answer needs a connected set of documents and records - not just chunked passages 
+- [x] B. The answer needs a connected set of documents and records - not just chunked passages
 - [ ] C. Vector search cannot index PDF files
 - [ ] D. The PDFs were not chunked at the right size
 

--- a/asciidoc/courses/workshop-lakehouse/modules/7-wrap-up/lessons/2-knowledge-check/questions/02-tree-shape.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/7-wrap-up/lessons/2-knowledge-check/questions/02-tree-shape.adoc
@@ -5,7 +5,7 @@ What does the `(Library)-[:HAS*]->(Section)` containment tree give an agent that
 
 - [ ] A. Faster text matching
 - [ ] B. Automatic summarization of each document
-- [x] C. The ability to navigate document structure - tables of contents, chapters, and what a document covers
+- [x] C. The ability to navigate library and document structure - tables of contents, chapters, and what a document covers
 - [ ] D. Smaller storage requirements
 
 [TIP,role=hint]

--- a/asciidoc/courses/workshop-lakehouse/modules/7-wrap-up/lessons/2-knowledge-check/questions/05-cross-boundary-paths.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/7-wrap-up/lessons/2-knowledge-check/questions/05-cross-boundary-paths.adoc
@@ -2,7 +2,7 @@
 = Why the Joins Needed a Graph
 
 To connect records on a real warehouse, the agent joins across many tables.
-Why is Text2SQL alone the wrong tool at that scale, and what makes the connections shape reliable?
+Why is Text2SQL alone the wrong tool at that scale, and what makes the connections shape more reliable?
 
 - [ ] A. SQL cannot express multi-table joins
 - [ ] B. The data is too large for a SQL engine

--- a/asciidoc/courses/workshop-lakehouse/summary.adoc
+++ b/asciidoc/courses/workshop-lakehouse/summary.adoc
@@ -11,7 +11,7 @@ You have learned:
 * How to federate the BigQuery warehouse with the graph - crossing the document-to-warehouse boundary, with nothing migrated
 * How to write multi-hop Cypher that crosses the document-to-table boundary
 * How to drive a coding agent to write Cypher from a spec - using the neo4j-cypher-skill instead of hand-writing queries
-* How use the Neo4j CLI for graph reasoning and make aviable for coding agents
+* How to use the Neo4j CLI for graph reasoning, and make it available to coding agents
 
 Continue your learning with the following resources:
 

--- a/asciidoc/courses/workshop-lakehouse/summary.adoc
+++ b/asciidoc/courses/workshop-lakehouse/summary.adoc
@@ -11,8 +11,7 @@ You have learned:
 * How to federate the BigQuery warehouse with the graph - crossing the document-to-warehouse boundary, with nothing migrated
 * How to write multi-hop Cypher that crosses the document-to-table boundary
 * How to drive a coding agent to write Cypher from a spec - using the neo4j-cypher-skill instead of hand-writing queries
-* How to drive the whole workflow with a coding agent using the Neo4j CLI
-* How to port the pattern to another lakehouse or domain
+* How use the Neo4j CLI for graph reasoning and make aviable for coding agents
 
 Continue your learning with the following resources:
 


### PR DESCRIPTION
## Summary
- Clean up the wrap-up module (M7), summary, and course.adoc
- Add extra **M2 environment-setup** steps to unblock edge cases (BigQuery/Neo4j config)
- Grammar/formatting sweep across M1, M2, M7, and summary
- Add a connections-graph visualization query; mark illustrative Cypher `norun`; correct lesson count to 17

## Notes
Content-only changes to `workshop-lakehouse` (now `:status: active`). No code or pipeline changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)