### PR TITLE
lakehouse-workshop: language simplification, grammar sweep, and Run-button fix on illustrative Cypher

### DIFF
--- a/asciidoc/courses/workshop-lakehouse/course.adoc
+++ b/asciidoc/courses/workshop-lakehouse/course.adoc
@@ -19,7 +19,7 @@ In this hands-on workshop, you give an agent three reusable shapes:
 * **Table of Contents (Trees & Links)** - navigate documents
 * **Themes (Communities)** - surface patterns nobody named
 
-These shapes answer the questions a modern stack gets quietly wrong - not just the single lookups it already handles most of the time, but the *estate-level* ones: the patterns across an entire document set, what your records show happening that the documentation never covers, and how things connect across a boundary no one query spans. Each needs the agent to cover, navigate, or follow the whole structure - not retrieve a similar slice.
+These shapes help answer the questions many modern stacks struggle with and get quietly wrong - not just the single lookups, but also the *estate-level* ones: the patterns across an entire document set, what your records show happening that the documentation never covers, and how things connect across a boundary no one query spans. Each needs the agent to cover, navigate, or follow the whole structure - not retrieve a similar slice.
 
 You work the pattern on AutoFix Group, a fictional auto-repair chain: manuals, bulletins, and recalls as PDFs alongside vehicles, work orders, and parts in a warehouse. In a hosted Codespace, you and your coding agent build a *service-advisor skill* shape by shape, then put it to work across both halves - federating the warehouse with the graph instead of migrating it.
 
@@ -42,7 +42,7 @@ For the hands-on path you will need a coding agent (this workshop assumes Claude
 
 == What you will learn
 
-* Why agent context is a problem of shapes, not queries - and where vector search and Text2SQL fall short
+* Why agent context is a problem of shapes, not queries - and where vector search and Text2SQL often fall short
 * How to build the connections shape with neocarta - the warehouse join paths, read from BigQuery as metadata
 * How to navigate documents with trees and links
 * How to surface themes with Leiden community detection

--- a/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/lessons/1-workshop-overview/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/lessons/1-workshop-overview/lesson.adoc
@@ -23,35 +23,31 @@ image::images/lakehouse-data.png[The AutoFix lakehouse: documents (manuals, serv
 
 Dani Reyes, a master technician, has a 2020 Falcon in the bay throwing misfire code `P0301`.
 There was a bulletin about a revised ignition coil - but which model years?
-On a single lookup like this, the modern stack does fine: the manual portal finds the bulletin, and the shop system knows the part that fixed it before. The agent can already reach both halves.
 
-The gap shows up one level up - on the questions that actually run the shop.
+Our connections and outline shape will help answer this question efficiently.
 
+Our shapes will also help with larger estate level questions that actually run the shop too.
 
 [.slide]
 == Three questions that break the stack
 
-Morgan Tao, VP of Service Ops, wants a copilot any technician can trust - not just for one car, but for the whole estate. Sam Okafor, the AI engineer, builds the obvious solution and hits three questions where it _looks_ like it answered, but didn't. To be clear up front: this is not about any one vendor being worse - the document and table tools did their jobs. What is missing is the _shape_.
+Morgan Tao, VP of Service Ops, wants a copilot any technician can trust - not just for one car, but for the whole estate. Some questions our shapes can help with:
 
 . **Connection - "how do these records relate?"** Point Text2SQL at a big, look-alike warehouse schema and it picks the wrong table, loops, runs up token cost, and on cheaper models often just gives up. It guesses how things join instead of following the structure - and every large warehouse, from supply chain to finance to life sciences, has this shape.
 . **Absence - "what is missing or unused?"** Similarity search only reaches what _resembles_ your query - it searches, it never navigates. So anything you would reach by following the structure of the documents, including what simply is not there, is out of reach: it cannot prove a negative. Sam had recurring fault codes with _zero_ documentation, and the agent reported them as documented, just buried. It is the same wall a legal team hits asking which contracts are missing a required clause, or a quality team asking which procedures were never written.
 . **Coverage - "what patterns run across all our documents?"** Top-k retrieval hands back the nearest handful and silently skips the rest. Sam put 112 bulletins and recalls in; it returned about seven patterns and even flagged its own coverage gaps. It samples when the question needs the whole set - the same whether you are clustering every incident report, supplier audit, or clinical-batch record in an estate.
 
-Each failure is a _different_ missing shape.
-The problem is not a bad model or a bad query - it is a lack of *context*.
-
-
 
 [.slide]
 == Context comes in shapes
 
-The fix is to give the agent the shapes its answers need:
+To help with the above we give the agent the shapes its answers need:
 
-* **Connections (Paths)** - how the warehouse tables join, in Module 2 - neocarta reads the foreign keys, so the agent follows the joins instead of guessing: the **Connection** question
-* **Table of Contents (Trees & Links)** - navigate the documents, in Module 3 - follow structure and tell "not there" from "not retrieved": the **Absence** question
-* **Themes (Communities)** - surface patterns nobody named, in Module 4 - cover and cluster the whole library instead of sampling: the **Coverage** question
+* **Connections (Paths)** - how the warehouse tables join, in Module 2 - neocarta reads the foreign keys, so the agent follows the joins instead of guessing.
+* **Table of Contents (Trees & Links)** - navigate the documents, in Module 3.
+* **Themes (Communities)** - surface patterns nobody named, in Module 4 - cover and cluster the whole library instead of sampling.
 
-And you learn a second axis: _where_ each shape should live. The connections graph is a *semantic layer* - only the warehouse's metadata (table names and foreign keys), not its rows - so the rows stay in BigQuery while the documents become graphs in Neo4j. The agent crosses between them on the keys they already share - part numbers and trouble codes.
+And you learn a second axis: _where_ each shape should live. The documents and the warehouse's connections become graphs in Neo4j; the warehouse rows stay in BigQuery; and the agent crosses between them on the keys they already share - part numbers and trouble codes.
 
 image::images/lakehouse-neo4j.png[The shape layer over the lakehouse: documents are parsed and ingested into a Neo4j document graph (Trees + Themes) and the warehouse's metadata into a connections graph, while the warehouse rows stay in BigQuery; the agent retrieves from the graphs directly and reads the warehouse with grounded SQL.]
 
@@ -68,20 +64,6 @@ Then you zoom out to the estate, where the shapes truly separate from the stack:
 
 You build the tools that answer them as a *service-advisor skill*, shape by shape, and leave with the code to point at your own lakehouse.
 
-
-[.slide]
-== Prerequisites and duration
-
-You should be able to read and run basic Cypher queries.
-No Graph Data Science experience is required - you will learn what you need in Module 4.
-
-Bring the coding agent you already use - Claude Code, Cursor, Codex, or similar.
-In each hands-on module, you and your agent build the skill's tools together, and every query is also runnable by hand in the sandbox if you prefer.
-
-The core path takes 90 minutes, with around 20 more minutes of optional practice - ideal for revisiting after a live session.
-
-The patterns are portable - the warehouse here is BigQuery, and Module 7 shows how to swap the connector for Snowflake, Databricks, or anywhere your data lives.
-
 read::Let's go![]
 
 
@@ -90,9 +72,9 @@ read::Let's go![]
 
 In this workshop, you will:
 
+* Build the **connections** shape so the agent follows the warehouse joins instead of guessing them
 * Build **navigation tools** over a document tree parsed from real PDFs
 * Build **theme tools** with community detection - patterns nobody named
-* Build the **connections** shape so the agent follows the warehouse joins instead of guessing them
-* Watch your agent answer the **estate-level questions** a modern stack gets wrong - covering the whole library, proving what is undocumented, and connecting documents to the records of what actually happened
+* Watch your agent answer operational and estate level questions using the shapes.
 
 In the next lesson, you will open your workshop environment and load the AutoFix lakehouse.

--- a/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/lessons/1-workshop-overview/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/lessons/1-workshop-overview/lesson.adoc
@@ -24,14 +24,14 @@ image::images/lakehouse-data.png[The AutoFix lakehouse: documents (manuals, serv
 Dani Reyes, a master technician, has a 2020 Falcon in the bay throwing misfire code `P0301`.
 There was a bulletin about a revised ignition coil - but which model years?
 
-Our connections and outline shape will help answer this question efficiently.
+Our connections and outline shapes will help answer this question efficiently.
 
-Our shapes will also help with larger estate level questions that actually run the shop too.
+Our shapes will also help with larger estate-level questions that actually run the shop.
 
 [.slide]
 == Three questions that break the stack
 
-Morgan Tao, VP of Service Ops, wants a copilot any technician can trust - not just for one car, but for the whole estate. Some questions our shapes can help with:
+Morgan Tao, VP of Service Ops, wants a copilot any technician can trust - not just for one car, but for the whole estate. Sam Okafor, the AI engineer, is building it - and running into some questions where the shapes are helpful:
 
 . **Connection - "how do these records relate?"** Point Text2SQL at a big, look-alike warehouse schema and it picks the wrong table, loops, runs up token cost, and on cheaper models often just gives up. It guesses how things join instead of following the structure - and every large warehouse, from supply chain to finance to life sciences, has this shape.
 . **Absence - "what is missing or unused?"** Similarity search only reaches what _resembles_ your query - it searches, it never navigates. So anything you would reach by following the structure of the documents, including what simply is not there, is out of reach: it cannot prove a negative. Sam had recurring fault codes with _zero_ documentation, and the agent reported them as documented, just buried. It is the same wall a legal team hits asking which contracts are missing a required clause, or a quality team asking which procedures were never written.
@@ -41,7 +41,7 @@ Morgan Tao, VP of Service Ops, wants a copilot any technician can trust - not ju
 [.slide]
 == Context comes in shapes
 
-To help with the above we give the agent the shapes its answers need:
+To help with the above, we give the agent the shapes its answers need:
 
 * **Connections (Paths)** - how the warehouse tables join, in Module 2 - neocarta reads the foreign keys, so the agent follows the joins instead of guessing.
 * **Table of Contents (Trees & Links)** - navigate the documents, in Module 3.
@@ -75,6 +75,6 @@ In this workshop, you will:
 * Build the **connections** shape so the agent follows the warehouse joins instead of guessing them
 * Build **navigation tools** over a document tree parsed from real PDFs
 * Build **theme tools** with community detection - patterns nobody named
-* Watch your agent answer operational and estate level questions using the shapes.
+* Watch your agent answer operational and estate-level questions using the shapes.
 
 In the next lesson, you will open your workshop environment and load the AutoFix lakehouse.

--- a/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/lessons/1-workshop-overview/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/lessons/1-workshop-overview/lesson.adoc
@@ -47,7 +47,7 @@ To help with the above, we give the agent the shapes its answers need:
 * **Table of Contents (Trees & Links)** - navigate the documents, in Module 3.
 * **Themes (Communities)** - surface patterns nobody named, in Module 4 - cover and cluster the whole library instead of sampling.
 
-And you learn a second axis: _where_ each shape should live. The documents and the warehouse's connections become graphs in Neo4j; the warehouse rows stay in BigQuery; and the agent crosses between them on the keys they already share - part numbers and trouble codes.
+And you learn a second axis: _where_ each shape should live. The connections graph is a *semantic layer* - only the warehouse's metadata (table names and foreign keys), not its rows - so the rows stay in BigQuery while the documents become graphs in Neo4j. The agent crosses between them on the keys they already share - part numbers and trouble codes.
 
 image::images/lakehouse-neo4j.png[The shape layer over the lakehouse: documents are parsed and ingested into a Neo4j document graph (Trees + Themes) and the warehouse's metadata into a connections graph, while the warehouse rows stay in BigQuery; the agent retrieves from the graphs directly and reads the warehouse with grounded SQL.]
 

--- a/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/lessons/2-your-environment/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/lessons/2-your-environment/lesson.adoc
@@ -8,7 +8,7 @@
 [.slide.discrete]
 == Introduction
 
-You saw the three questions that break the stack in the previous lesson.
+You saw questions that challenged the agent in the previous section.
 You will answer them the way you would on the job: by building a **service-advisor skill** - the shaped tools your coding agent runs to cover, navigate, and connect the AutoFix lakehouse.
 
 In this lesson, you will open your workshop environment and connect it to both halves of the lakehouse: the Neo4j sandbox and the BigQuery warehouse.

--- a/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/lessons/2-your-environment/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/1-context-problem/lessons/2-your-environment/lesson.adoc
@@ -8,7 +8,7 @@
 [.slide.discrete]
 == Introduction
 
-You saw questions that challenged the agent in the previous section.
+You saw questions that challenged the agent in the previous lesson.
 You will answer them the way you would on the job: by building a **service-advisor skill** - the shaped tools your coding agent runs to cover, navigate, and connect the AutoFix lakehouse.
 
 In this lesson, you will open your workshop environment and connect it to both halves of the lakehouse: the Neo4j sandbox and the BigQuery warehouse.

--- a/asciidoc/courses/workshop-lakehouse/modules/2-connections/lessons/1-connections-shape/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/2-connections/lessons/1-connections-shape/lesson.adoc
@@ -7,9 +7,7 @@
 [.slide.discrete]
 == Introduction
 
-The warehouse holds the answer to "what did we do last time on cars like this?" - across vehicles, work orders, and parts. The obvious tool, Text2SQL, can write the query, but on a multi-table join it is _quietly wrong_: it guesses which columns join, and a plausible-looking join on the wrong key returns plausible-looking nonsense.
-
-//TODO: An example of wrong SQL would be nice
+The warehouse holds the answer to "what did we do last time on cars like this?" - across vehicles, work orders, and parts. The obvious tool, Text2SQL, can write the query, but on a multi-table join it can be _quietly wrong_: it guesses which columns join, and a plausible-looking join on the wrong key returns plausible-looking nonsense.
 
 In this lesson, you will learn the shape that fixes it - the connections graph - and the rule for where it should live.
 
@@ -19,7 +17,7 @@ In this lesson, you will learn the shape that fixes it - the connections graph -
 
 A warehouse is a set of tables wired together by foreign keys: a work order's `vin` points at a vehicle, its `dtc_code` at a trouble code, a parts line at both a work order and a part. Those foreign keys _are_ the legal joins.
 
-Text2SQL does not see them as a structure - it infers joins from column names and hopes. The **connections shape** makes them explicit and traversable: an agent that can read "`work_orders` joins to `vehicles` on `vin`" writes the right join instead of guessing it.
+Text2SQL does not always see them as a structure - it often infers joins from column names and hopes. The **connections shape** makes them explicit and traversable: an agent that can read "`work_orders` joins to `vehicles` on `vin`" writes the right join instead of guessing it.
 
 [NOTE]
 .It can write the join - it just guesses the keys
@@ -36,7 +34,6 @@ graph LR
     WO -->|dtc_code| D((dtc_codes))
     WO -->|procedure_id| PR((procedures))
 ----
-//TODO: Replace above with an ERD diagram reflecting how it would normally be visualized for RDBMS.  If Metmaid isn't the right visual fit lets use another tool and place img here if we have to.
 
 [.slide]
 == Building the semantic layer

--- a/asciidoc/courses/workshop-lakehouse/modules/2-connections/lessons/2-build-connections/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/2-connections/lessons/2-build-connections/lesson.adoc
@@ -53,7 +53,7 @@ The server gives your agent five tools:
 
 This is how the agent reads the connections shape at runtime.
 
-// TODO - Below example would be better if contrasted against neocarta case.  do both ways and dem onstrate difference.
+// TODO - Below example would be better if contrasted against neocarta case.  do both ways and demonstrate difference.
 
 [.slide]
 == Ask a question that needs a four-table join

--- a/asciidoc/courses/workshop-lakehouse/modules/2-connections/module.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/2-connections/module.adoc
@@ -1,7 +1,7 @@
 = Connections - the structured shape
 :order: 2
 
-Sam's second wall: Text2SQL is quietly wrong on multi-hop joins. The fix is not a better model - it is giving the agent the *connections*: how the warehouse tables actually join.
+Text2SQL can be quietly wrong on multi-hop joins. The fix is not a better model - it is giving the agent the *connections*: how the warehouse tables actually join.
 
 In this module, you use neocarta to read the warehouse's foreign keys out of BigQuery and into a Neo4j metadata graph - the join-path map - without moving a single row.
 

--- a/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/2-navigation-tools/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/2-navigation-tools/lesson.adoc
@@ -44,7 +44,7 @@ Test it:
 [source,shell]
 ----
 python skill/scripts/outline.py # renders whole thing, quite large
-python skill/scripts/outline.py --depth 1 # regulate depth
+python skill/scripts/outline.py --depth 1 # limit depth
 python skill/scripts/outline.py technical-library/bulletins/tsb-20-501.pdf # specific uri
 ----
 

--- a/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/2-navigation-tools/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/2-navigation-tools/lesson.adoc
@@ -43,8 +43,9 @@ Test it:
 
 [source,shell]
 ----
-python skill/scripts/outline.py
-python skill/scripts/outline.py technical-library/bulletins/tsb-20-501.pdf
+python skill/scripts/outline.py # renders whole thing, quite large
+python skill/scripts/outline.py --depth 1 # regulate depth
+python skill/scripts/outline.py technical-library/bulletins/tsb-20-501.pdf # specific uri
 ----
 
 You should see the full library ToC, then the bulletin's subtree - with `→` rows showing the links its author wrote into the manuals: the Falcon misfire-diagnosis procedure, the Heron coil identification and replacement sections, and the spark-plug specs.

--- a/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/2-navigation-tools/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/2-navigation-tools/lesson.adoc
@@ -31,7 +31,7 @@ solutions/ for this exercise.
 
 Review what it writes - the reasoning it must land on:
 
-[source,cypher,role=norun]
+[source,text]
 .The walk that materializes a tree of unknown depth
 ----
 MATCH path = (root)-[:HAS*0..25]->(n)
@@ -65,7 +65,7 @@ to fill in its query. Do not reference anything in solutions/ for this exercise.
 
 The index already exists (the pipeline created `content_search` over `Document|Section`); the query calls it, then **scopes by subtree**:
 
-[source,cypher,role=norun]
+[source,text]
 .The index ranks, the graph scopes
 ----
 CALL db.index.fulltext.queryNodes('content_search', $lucene)

--- a/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/3-navigate-the-shape/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/lessons/3-navigate-the-shape/lesson.adoc
@@ -8,7 +8,7 @@
 [.slide.discrete]
 == Challenge
 
-Your navigation tools exist - now stretch them on three questions Dani's keyword portal could not answer.
+Your navigation tools exist - now stretch them on three of Dani's questions.
 Use the tools first; each slide also shows the Cypher underneath, to run in the sandbox and see what the tool traverses.
 
 

--- a/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/module.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/3-navigate-documents/module.adoc
@@ -2,7 +2,7 @@
 :order: 3
 
 Search finds what looks similar; navigation follows the structure to what you actually need — the complement that reads the table of contents before flipping through every page.
-In this module, you will read the spec for the outline shape, derive the graph reasoning it needs, and build your skill's navigation tools - then put them to work on the questions keyword search cannot answer.
+In this module, you will read the spec for the outline shape, derive the graph reasoning it needs, and build your skill's navigation tools - then put them to work.
 
 
 By the end of this module, you will:

--- a/asciidoc/courses/workshop-lakehouse/modules/4-surface-themes/lessons/2-detect-themes/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/4-surface-themes/lessons/2-detect-themes/lesson.adoc
@@ -27,7 +27,7 @@ Section URIs use a `#` fragment identifier to separate the document path from th
 For example, `technical-library/manuals/falcon-electrical#can-bus-diagnosis` belongs to the document `technical-library/manuals/falcon-electrical`.
 Splitting on `#` and taking the first element is all the lookup needs:
 
-[source,cypher,role=norun]
+[source,text]
 .Example fragment - `s` is a Section node already matched in the outer query
 ----
 // s is a :Section node already in scope

--- a/asciidoc/courses/workshop-lakehouse/modules/6-put-it-together/lessons/1-more-than-one-shape/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/6-put-it-together/lessons/1-more-than-one-shape/lesson.adoc
@@ -7,7 +7,7 @@
 [.slide.discrete]
 == Introduction
 
-You have built all three shapes - trees and themes over the documents, connections over the warehouse. The finale is the point of all of it: answering the questions you set out to answer back in Module 1.
+You have built all three shapes - trees and themes over the documents, connections over the warehouse. Here you set out to leverage them and answer the questions from Module 1.
 
 Those questions do not fall to a single shape. This short lesson is the warm-up - Dani's own question - where you see why, before the estate questions in the next challenge.
 
@@ -36,7 +36,7 @@ That read from Neo4j and BigQuery in the same pass - but that is just what reach
 [.slide]
 == The connections shape keeps the warehouse half honest
 
-The warehouse step is a multi-table join - work orders to vehicles to parts. Left to guess, Text2SQL is quietly wrong as the chain grows. The agent does not guess: it reads the foreign keys from the connections MCP you built in Module 2 and writes the SQL along the real join paths.
+The warehouse step is a multi-table join - work orders to vehicles to parts. Left to guess, Text2SQL may be quietly wrong as the chain grows. The agent does not guess: it reads the foreign keys from the connections MCP you built in Module 2 and writes the SQL along the real join paths.
 
 And nothing here is new plumbing - the documents are already a graph, the warehouse rows already stay in BigQuery (that was Module 2). The finale just puts the shapes to work together.
 
@@ -48,8 +48,8 @@ read::Continue to the challenge[]
 
 In this lesson, you saw the finale's move - answering with more than one shape:
 
-* **One shape is never the whole answer** - Dani's question needs the documents *and* the warehouse
-* **Documents name the candidates; the warehouse says which held up** - the agent reaches for both and the answer falls out
+* **One shape may not be the whole answer** - Dani's question needs the documents *and* the warehouse
+* **Documents name the candidates; the warehouse says which held up** - the agent reaches for both to answer
 * **The connections shape keeps the warehouse query honest** - the join paths from Module 2, not guesses
 * **Touching both stores is a byproduct** of reaching for both shapes - not the achievement
 

--- a/asciidoc/courses/workshop-lakehouse/modules/6-put-it-together/lessons/2-estate-questions/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/6-put-it-together/lessons/2-estate-questions/lesson.adoc
@@ -45,7 +45,7 @@ and the actual problems in the field? What documentation is missing, and what
 documentation isn't used?
 ----
 
-A similarity tool _cannot_ answer this honestly. Asked what is undocumented, it returns the nearest-looking sections and concludes the codes are "documented, just buried" - a confident, wrong claim, because similarity always returns *something* and can never prove absence. The tree shape enumerates: it walks every document and reports the codes with zero hits.
+A similarity tool _cannot_ answer this honestly. Asked what is undocumented, it returns the nearest-looking sections and may conclude the codes are "documented, just buried" - a confident, wrong claim, because similarity always returns *something* and can never prove absence. The tree shape enumerates: it walks every document and reports the codes with zero hits.
 
 [TIP]
 .Verify it in the sandbox - the query is the proof

--- a/asciidoc/courses/workshop-lakehouse/modules/6-put-it-together/module.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/6-put-it-together/module.adoc
@@ -1,16 +1,16 @@
 = Put It Together - the finale
 :order: 6
 
-Three questions broke the stack back in Module 1: what is undocumented, what patterns run across the whole library, and how the records actually connect. You now have a shape for each.
+Three questions risk breaking the stack back in Module 1: what is undocumented, what patterns run across the whole library, and how the records actually connect. You now have a shape for each.
 
-In this module you put them together to answer those questions. You start on Dani's car - where one shape is not enough - and watch the agent reach for the documents and the warehouse in a single answer. Then you zoom out to the estate questions, where the shapes provide decisive value: covering and clustering the whole library, and proving what the documents never say.
+In this module you put them together to answer those questions. You start on Dani's car - where one shape is not enough - and watch the agent reach for the documents and the warehouse in a single answer. Then you zoom out to the estate questions, where the shapes provide even more value: covering and clustering the whole library, and proving what the documents never say.
 
 
 By the end of this module, you will:
 
 * Answer a question no single shape can - the agent grounds candidates in the document shapes, then reads the warehouse with Text2SQL the connections shape keeps honest
-* Answer the estate questions a modern stack gets wrong - the patterns across *all* the bulletins and recalls, and the field codes with *no* documentation
-* See why similarity retrieval samples and cannot prove a negative - and why the shapes cover and connect the whole structure instead
+* Answer the estate questions many modern stacks struggle with - the patterns across *all* the bulletins and recalls, and the field codes with *no* documentation
+* See why similarity retrieval samples and cannot easily prove a negative - and why the shapes cover and connect the whole structure instead
 
 
 link:./1-more-than-one-shape/[Ready? Let's go →, role=btn]

--- a/asciidoc/courses/workshop-lakehouse/modules/6-put-it-together/module.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/6-put-it-together/module.adoc
@@ -1,7 +1,7 @@
 = Put It Together - the finale
 :order: 6
 
-Three questions risk breaking the stack back in Module 1: what is undocumented, what patterns run across the whole library, and how the records actually connect. You now have a shape for each.
+Back in Module 1, three questions risked breaking the stack: what is undocumented, what patterns run across the whole library, and how the records actually connect. You now have a shape for each.
 
 In this module you put them together to answer those questions. You start on Dani's car - where one shape is not enough - and watch the agent reach for the documents and the warehouse in a single answer. Then you zoom out to the estate questions, where the shapes provide even more value: covering and clustering the whole library, and proving what the documents never say.
 


### PR DESCRIPTION
## Summary
- Simplify language across the workshop (overview, connections, navigation, finale)
- Grammar sweep; restore the Sam persona after the language-softening pass
- Unblock the **Run button** on illustrative Cypher: switch `norun` fragments to `source,text`

## Notes
Content-only changes to `workshop-lakehouse` (`:status: active`, live). No code or pipeline changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)