### PR TITLE
lakehouse-workshop: runthrough tweaks — tighten M2 example, add M6 estate-question prompt guidance

### DIFF
--- a/asciidoc/courses/workshop-lakehouse/modules/2-connections/lessons/2-build-connections/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/2-connections/lessons/2-build-connections/lesson.adoc
@@ -72,12 +72,10 @@ Watch what it does:
 
 . calls `get_full_metadata_schema` on the `connections` server - and reads that `work_order_parts` references both `parts` and `work_orders`, and `work_orders` references `vehicles`
 . writes the join along those foreign keys: `parts → work_order_parts → work_orders → vehicles`
-. runs it and reports the rows - seven Falcon 2.0T vehicles, every one a misfire code
+. runs it and reports the rows
 
 The agent never guessed a join. It read the foreign keys from the graph and wrote the SQL from them - Text2SQL grounded by the connections shape.
-////
-TODO - Above example is misaligned nothing about misfires
-////
+
 [NOTE]
 .Why this matters
 ====

--- a/asciidoc/courses/workshop-lakehouse/modules/6-put-it-together/lessons/2-estate-questions/lesson.adoc
+++ b/asciidoc/courses/workshop-lakehouse/modules/6-put-it-together/lessons/2-estate-questions/lesson.adoc
@@ -23,8 +23,10 @@ The agent does not run a hand-written query. It retrieves the warehouse schema f
 [source,text]
 .A prompt for your coding agent
 ----
-For VIN FAL20T20220002 with code P0301: what fixed this on similar
-vehicles?
+For VIN FAL20T20220002 with code P0301: what fixed this on similar vehicles?
+
+Explain the steps and shapes you used concisely.
+For sake of clarity, avoid using the neo4j-cli for this one question.
 ----
 
 Watch it call the `connections` tools, write the SQL from the foreign keys, and run it. The candidate parts come from the bulletin sections that name the code; the warehouse says which of them actually held up.
@@ -41,8 +43,11 @@ That was one car. The estate questions ask about the *whole* library at once - a
 .A prompt for your coding agent
 ----
 Are there mismatches between our documented procedures
-and the actual problems in the field? What documentation is missing, and what
-documentation isn't used?
+and the actual problems in the field?
+What documentation is missing, and what documentation isn't used?
+
+Explain the steps and shapes you used concisely.
+For sake of clarity, avoid using the neo4j-cli for this one question.
 ----
 
 A similarity tool _cannot_ answer this honestly. Asked what is undocumented, it returns the nearest-looking sections and may conclude the codes are "documented, just buried" - a confident, wrong claim, because similarity always returns *something* and can never prove absence. The tree shape enumerates: it walks every document and reports the codes with zero hits.
@@ -74,8 +79,11 @@ The other estate question - Morgan wants the common patterns across the whole li
 [source,text]
 .A prompt for your coding agent
 ----
-What are the common patterns across our bulletins and recalls? How
-many of our cars does each affect?
+What are the common patterns across our bulletins and recalls?
+How many of our cars does each affect?
+
+Explain the steps and shapes you used concisely.
+For sake of clarity, avoid using the neo4j-cli for this one question.
 ----
 
 This is a **coverage** question, and it is where similarity retrieval breaks. Ask a top-k retriever for "patterns across all our notices" and it hands back the nearest handful - it samples, and it cannot tell you what it skipped. That is not a vendor flaw; it is what similarity retrieval _is_, and it is the engine under every lakehouse AI-search feature.


### PR DESCRIPTION
## Summary
- Tighten the M2 build-connections example
- Add prompt guidance in the M6 estate-questions lesson

## Notes
Content-only runthrough tweaks to `workshop-lakehouse` (`:status: active`, live). No code or pipeline changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)